### PR TITLE
CodecKit trailer format update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [main, '1.4.0']
+    branches: [main, '[0-9]*']
   pull_request:
-    branches: [main, '1.4.0']
-
+    branches: [main, '[0-9]*']
 jobs:
   build:
     if: |

--- a/docs/articles/ADRs/ADR008-stored-fields-v2-streaming.md
+++ b/docs/articles/ADRs/ADR008-stored-fields-v2-streaming.md
@@ -1,7 +1,8 @@
 # ADR008: Streaming codec formats bypass the CodecKit envelope
 
 - **Date:** 2026-07-09
-- **Status:** Accepted
+- **Status:** Deprecated
+- **Superseeded by**: ADR009
 
 ## Context
 

--- a/docs/articles/ADRs/ADR009-codeckit-trailer-streaming.md
+++ b/docs/articles/ADRs/ADR009-codeckit-trailer-streaming.md
@@ -1,0 +1,153 @@
+# ADR009: CodecKit trailer format replaces ADR008 custom headers
+
+- **Date:** 2026-07-11
+- **Status:** Accepted
+- **Supersedes:** ADR008
+
+## Context
+
+ADR008 introduced v2 streaming formats for stored fields and postings that
+bypassed CodecKit entirely, using a bare version byte with no body-length
+prefix. This solved the buffering problem for those two codec types, but
+left the remaining eleven codec types (DocValues, Norms, FieldLengths,
+TermVectors, Int64 variants) stuck with the CodecKit envelope
+`[version:byte][VarInt64 bodyLen][body]`. The envelope's variable-length
+bodyLen forces writers to buffer the complete body before the first byte
+hits disk.
+
+The `IndexCodecMigrator.RewritePostings` materialised all terms and
+posting rows into a `List<(string, List<PostingRow>)>` before writing.
+Seven DocValues/FieldLengths rewrite methods each loaded full
+`Dictionary<string, T[]>` via `WriteSingleFileAtomically` which buffered
+the entire body in a CodecKit envelope. TermVectorsWriter and
+TermVectorsStreamWriter buffered the complete `.tvd` body to compute the
+envelope header size for `.tvx` offset rebasing.
+
+The custom v2 headers created a split ecosystem: some codecs used
+CodecKit, others used their own `*FileHeader` helpers. The migrator had
+to special-case these formats.
+
+## Decision
+
+Add a **trailer-based format** to CodecKit that can coexist with the
+existing envelope:
+
+```
+Trailer:  [version:byte][body][bodyLen:int64]
+Envelope: [version:byte][VarInt64 bodyLen][body]
+```
+
+The 8-byte fixed `Int64` trailer is appended after the body is complete.
+The writer calls `BeginStreamingWrite(output, version)` which writes the
+version byte and returns a scope; callers write the body incrementally
+to `scope.Output`; disposing the scope appends the trailer. Two reader
+APIs handle detection:
+
+- `ReadVersionAndSkipHeader`: returns the version and leaves the input
+  positioned at body start.  Zero allocation, no materialisation.  Used by
+  streaming readers (StoredFields, Postings).
+- `ReadBody`: returns the full body as `byte[]`.  Used by callers that
+  already materialise (TermDictionaryReader, RoaringBitmap, tests).
+
+Trailer detection reads the last 8 bytes of the file and checks
+`1 + bodyLen + 8 == fileLength`. For envelope files this check fails
+(they have `1 + varIntSize + bodyLen` total), so the reader falls back
+to the VarInt64-based envelope path. The false-positive risk is
+vanishingly small and disambiguated by the version byte.
+
+### Version bumps
+
+All twelve codec types that use the trailer format have their version
+constants bumped. Body formats are unchanged; only the outer wrapping
+differs.
+
+| Codec | Old | New |
+|-------|-----|-----|
+| StoredFields | 2 (custom) | 3 (trailer) |
+| Postings | 2 (custom) | 3 (trailer) |
+| Norms | 2 (envelope) | 3 (trailer) |
+| TermVectors | 2 (envelope) | 3 (trailer) |
+| NumericDocValues | 1 (envelope) | 2 (trailer) |
+| SortedDocValues | 1 (envelope) | 2 (trailer) |
+| SortedSetDocValues | 1 (envelope) | 2 (trailer) |
+| SortedNumericDocValues | 1 (envelope) | 2 (trailer) |
+| BinaryDocValues | 1 (envelope) | 2 (trailer) |
+| FieldLengths | 1 (envelope) | 2 (trailer) |
+| Int64DocValues | 1 (envelope) | 2 (trailer) |
+| Int64SortedNumericDocValues | 1 (envelope) | 2 (trailer) |
+
+Vectors, BKD, RoaringBitmap, and TermDictionary are unchanged.
+
+### Codec migration
+
+The index codec migrator now streams data through:
+
+- `RewritePostings`: iterates terms lazily via `EnumerateTerms()`,
+  writes each term's postings immediately via `BeginStreamingWrite` +
+  `BlockPostingsWriter`. No materialisation of the full postings list.
+- DocValues/FieldLengths rewrites: two-pass field enumeration via
+  `EnumerateFields()`. First pass counts fields and determines max
+  doc count; second pass serialises each field to a reusable
+  `ArrayBufferWriter<byte>` and writes to the trailer scope. Memory is
+  O(largest single field), not O(all fields).
+- `WriteSingleFileAtomically` deleted; all seven rewrite methods
+  manage their own temp-file lifecycle.
+
+### ADR008 codecs folded into CodecKit
+
+Stored fields, postings, and term vectors now use `CodecFileHeader`
+instead of their custom `*FileHeader` write helpers:
+
+- `StoredFieldsFileHeader.WriteV2FdtHeader` deleted; replaced by
+  `BeginStreamingWrite` + block metadata. `.fdx` bumped to v3 via
+  `WriteV3FdxHeader`.
+- `PostingsFileHeader.WriteV2Header` deleted; replaced by
+  `BeginStreamingWrite`. `WriteV1Header` was already dead code.
+- TermVectors no longer buffers `.tvd` body; offsets are captured as
+  file-absolute `scope.Output.Position` values during the write.
+  `headerSize` rebasing removed.
+
+Readers accept v1, v2, and v3: `StoredFieldsReader.Open` bumps version
+guards to `> V3`; `PostingsEnum.ValidateFileHeader` uses the bumped
+`CodecConstants.PostingsVersion`; `TermVectorsReader.Open` delegates to
+the trailer-aware `ReadVersion`.
+
+## Rationale
+
+The trailer format fixes the root cause at the CodecKit level rather
+than bypassing it per codec type. One pattern serves all writers.
+Existing envelope files remain readable through automatic fallback
+detection. The custom v2 headers from ADR008 are removed, consolidating
+the codec ecosystem.
+
+The 8-byte fixed trailer was chosen over a post-body VarInt64 to avoid
+ambiguity: VarInt64 can be 1 to 9 bytes, making the exact file end
+position of the bodyLen value unknown. A fixed 8-byte `Int64` trailer
+can always be read by seeking to `length - 8`.
+
+## Consequences
+
+- `CodecFileHeader` gains `StreamingWriteScope`, `BeginStreamingWrite`,
+  `ReadVersionAndSkipHeader`, and `ReadBody`. Twelve codec version
+  constants are bumped.
+- `PostingsFileHeader`, `StoredFieldsFileHeader` lose their write
+  helpers; only `ReadVersion` and skip-data helpers remain.
+- `StoredFieldsFileHeader.WriteV2FdtHeader`, `WriteV2FdxHeader` deleted;
+  `WriteV3FdxHeader` added.
+- `TermVectorsWriter` and `TermVectorsStreamWriter` no longer buffer
+  the `.tvd` body; `headerSize` rebasing removed.
+- `IndexCodecMigrator.WriteSingleFileAtomically` deleted; all eight
+  rewrite methods manage their own temp-file output.
+- `TermDictionaryReader.EnumerateTerms` added (lazy FST enumeration).
+- Seven DocValues readers gain `EnumerateFields`; `NormsWriter` and
+  `FieldLengthWriter` gain `WriteFieldBlock` helpers.
+- `NumericDocValuesWriter.WriteFieldBlock(IBufferWriter<byte>,...)` and
+  `SortedDocValuesWriter.WriteFieldBlock(IBufferWriter<byte>,...)`
+  visibility changed from `private` to `internal`.
+- `ReadVarInt64` (ZigZag-decoded) added to `CodecFileHeader` for
+  envelope fallback parsing.
+- `BinaryReader` overloads of `ReadVersionAndSkipHeader` and `ReadBody`
+  remain envelope-only for now; BinaryReader internal buffering makes
+  stream-seeking unsafe. Stored fields reader handles v3 by bumping
+  version guards rather than using these overloads.
+- Existing v1 and v2 indexes remain readable through version fallback.

--- a/docs/articles/ADRs/index.md
+++ b/docs/articles/ADRs/index.md
@@ -9,8 +9,8 @@
 | ADR005 | 2026-06-16 | Accepted | [Each DWPT flushes its own segment](ADR005-dwpt-segment-flush.md) |
 | ADR006 | 2026-06-17 | Accepted | [Defer Stryker.NET mutation testing until upstream bug is fixed](ADR006-stryker-deferred.md) |
 | ADR007 | 2026-06-18 | Accepted | [Background merges must never block Commit](ADR007-merge-must-not-block-commit.md) |
-| ADR008 | 2026-07-09 | Accepted | [Streaming codec formats bypass the CodecKit envelope](ADR008-stored-fields-v2-streaming.md) |
-
+| ADR008 | 2026-07-09 | Deprecated | [Streaming codec formats bypass the CodecKit envelope](ADR008-stored-fields-v2-streaming.md) |
+| ADR009 | 2026-07-11 | Accepted | [CodecKit trailer format replaces ADR008 custom headers](ADR009-codeckit-trailer-streaming.md) |
 ## Template
 
 New ADRs should follow [the template](_template.md) using the next available `ADRnnn` prefix.

--- a/src/core/Rowles.LeanCorpus/Codecs/CodecConstants.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/CodecConstants.cs
@@ -2,30 +2,32 @@ namespace Rowles.LeanCorpus.Codecs;
 
 /// <summary>
 /// Format version constants for all codec file types.
-/// Most codec files use the CodecKit envelope: [byte version][VarInt64 bodyLen][body].
-/// Stored fields (.fdt/.fdx) use a streaming v2 layout without a body-length prefix.
+/// Most codec files use the CodecKit envelope: [byte version][VarInt64 bodyLen][body]
+/// and are being migrated to a trailer format: [byte version][body][bodyLen:int64].
+/// Stored fields and postings previously used a streaming v2 layout without a
+/// body-length prefix; these are now folded into the CodecKit trailer format.
 /// </summary>
 internal static class CodecConstants
 {
-    // Baseline format versions for 2.0.0. TermVectors is at v2 due to the tvx offset-array
-    // addition; all other formats start at v1.
+    // v2 -> v3 bumps for streaming trailer: postings, norms, stored fields, term vectors.
+    // v1 -> v2 bumps for streaming trailer: all DocValues, field lengths, Int64 variants.
     public const byte TermDictionaryVersion = 1;
-    public const byte PostingsVersion = 2;
-    public const byte NormsVersion = 2;
+    public const byte PostingsVersion = 3;
+    public const byte NormsVersion = 3;
     public const byte VectorVersion = 1;
     public const byte QuantisedVectorVersion = 1;
     public const byte HnswVersion = 1;
-    public const byte StoredFieldsVersion = 2;
-    public const byte TermVectorsVersion = 2;
-    public const byte NumericDocValuesVersion = 1;
-    public const byte SortedDocValuesVersion = 1;
-    public const byte SortedSetDocValuesVersion = 1;
-    public const byte SortedNumericDocValuesVersion = 1;
-    public const byte BinaryDocValuesVersion = 1;
+    public const byte StoredFieldsVersion = 3;
+    public const byte TermVectorsVersion = 3;
+    public const byte NumericDocValuesVersion = 2;
+    public const byte SortedDocValuesVersion = 2;
+    public const byte SortedSetDocValuesVersion = 2;
+    public const byte SortedNumericDocValuesVersion = 2;
+    public const byte BinaryDocValuesVersion = 2;
     public const byte BKDVersion = 1;
-    public const byte Int64DocValuesVersion = 1;
-    public const byte Int64SortedNumericDocValuesVersion = 1;
+    public const byte Int64DocValuesVersion = 2;
+    public const byte Int64SortedNumericDocValuesVersion = 2;
     public const byte Int64BKDVersion = 1;
-    public const byte FieldLengthVersion = 1;
+    public const byte FieldLengthVersion = 2;
     public const byte RoaringBitmapVersion = 1;
 }

--- a/src/core/Rowles.LeanCorpus/Codecs/CodecKit/CodecFileHeader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/CodecKit/CodecFileHeader.cs
@@ -7,13 +7,12 @@ namespace Rowles.LeanCorpus.Codecs.CodecKit;
 
 /// <summary>
 /// CodecKit file header read/write for codec files.
-/// CodecKit format: [byte version][VarInt64 bodyLen][body]
+/// Supports two formats:
+///   Envelope: [version:byte][VarInt64 bodyLen][body]
+///   Trailer:  [version:byte][body][bodyLen:int64]  (8-byte fixed trailer)
 /// </summary>
 public static class CodecFileHeader
 {
-    /// <summary>
-    /// The result of reading a codec file body, including the format version.
-    /// </summary>
     public readonly struct ReadResult
     {
         public byte[] Body { get; }
@@ -21,11 +20,170 @@ public static class CodecFileHeader
         public ReadResult(byte[] body, byte version) { Body = body; Version = version; }
     }
 
+    // -- Streaming write (trailer format) -----------------------------------
+
+    public sealed class StreamingWriteScope : IDisposable
+    {
+        public IndexOutput Output { get; }
+        private readonly long _bodyStart;
+        private bool _disposed;
+
+        internal StreamingWriteScope(IndexOutput output, long bodyStart)
+        {
+            Output = output;
+            _bodyStart = bodyStart;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            long bodyLen = Output.Position - _bodyStart;
+            Output.WriteInt64(bodyLen);
+        }
+    }
+
+    public static StreamingWriteScope BeginStreamingWrite(IndexOutput output, byte version)
+    {
+        output.WriteByte(version);
+        long bodyStart = output.Position;
+        return new StreamingWriteScope(output, bodyStart);
+    }
+
+    // -- Streaming reader (IndexInput) --------------------------------------
+
+    /// <summary>
+    /// Detects trailer vs envelope format, returns the version byte, and leaves
+    /// <paramref name="input"/> positioned at the start of the body.
+    /// </summary>
+    public static byte ReadVersionAndSkipHeader(IndexInput input)
+    {
+        if (input.Length < 1)
+            throw new InvalidDataException("CodecKit file is truncated.");
+
+        long startPos = input.Position;
+        byte version = input.ReadByte();
+        long frameLen = input.Length - startPos;
+
+        // Try trailer: last 8 bytes form a self-consistent bodyLen.
+        if (frameLen >= 9)
+        {
+            input.Seek(input.Length - 8);
+            long bodyLen = input.ReadInt64();
+            if (1L + bodyLen + 8L == frameLen && bodyLen >= 0)
+            {
+                input.Seek(startPos + 1);
+                return version;
+            }
+        }
+
+        // Envelope: skip VarInt64 bodyLen.
+        input.Seek(startPos + 1);
+        SkipVarInt64(input);
+        return version;
+    }
+
+    /// <summary>
+    /// <c>BinaryReader</c> overload.  Envelope-only for now; trailer detection
+    /// via BinaryReader is not safe due to internal buffering (addressed in
+    /// Phase C when StoredFieldsReader handles v3).
+    /// </summary>
+    public static byte ReadVersionAndSkipHeader(BinaryReader reader)
+    {
+        byte version = reader.ReadByte();
+        SkipVarInt64(reader);
+        return version;
+    }
+
+    // -- Full-body materialising reads (IndexInput) -------------------------
+
+    /// <summary>
+    /// Detects format and returns the full body as a byte[].
+    /// For envelope files the body codec may add its own framing;
+    /// prefer <see cref="Read(IndexInput, ICodec{byte[]})"/> for those.
+    /// </summary>
+    public static ReadResult ReadBody(IndexInput input)
+    {
+        long startPos = input.Position;
+        if (input.Length - startPos < 1)
+            throw new InvalidDataException("CodecKit file is truncated.");
+
+        byte version = input.ReadByte();
+        long frameLen = input.Length - startPos;
+
+        if (frameLen >= 9)
+        {
+            input.Seek(input.Length - 8);
+            long bodyLen = input.ReadInt64();
+            if (1L + bodyLen + 8L == frameLen && bodyLen >= 0)
+            {
+                byte[] body;
+                if (bodyLen == 0)
+                    body = [];
+                else
+                {
+                    input.Seek(startPos + 1);
+                    body = new byte[bodyLen];
+                    for (long i = 0; i < bodyLen; i++)
+                        body[i] = input.ReadByte();
+                }
+                return new ReadResult(body, version);
+            }
+        }
+
+        // Envelope: read ZigZag-encoded VarInt64 bodyLen, then body.
+        input.Seek(startPos + 1);
+        long envBodyLen = ReadVarInt64(input);
+        if (envBodyLen < 0 || envBodyLen > int.MaxValue)
+            throw new InvalidDataException($"Invalid envelope body length: {envBodyLen}");
+        byte[] envBody = new byte[(int)envBodyLen];
+        for (int i = 0; i < (int)envBodyLen; i++)
+            envBody[i] = input.ReadByte();
+        return new ReadResult(envBody, version);
+    }
+
+    // ReadBody(BinaryReader) omitted; BinaryReader paths need a format
+    // parameter for correct decode.  Use Read(BinaryReader, ICodec<byte[]>) instead.
+
+
+    // -- Legacy Read / ReadVersion ------------------------------------------
+
+    /// <summary>
+    /// Reads and decodes a codec file.  Detects trailer format (raw body)
+    /// and falls back to envelope format via the codec-chain decode path.
+    /// </summary>
     public static ReadResult Read(IndexInput input, ICodec<byte[]> format)
     {
-        long remaining = input.Length - input.Position;
-        if (remaining < 1)
+        if (input.Length - input.Position < 1)
             throw new InvalidDataException("CodecKit file is truncated: no payload bytes found.");
+
+        long startPos = input.Position;
+        long frameLen = input.Length - startPos;
+
+        if (frameLen >= 9)
+        {
+            input.Seek(input.Length - 8);
+            long bodyLen = input.ReadInt64();
+            if (1L + bodyLen + 8L == frameLen && bodyLen >= 0)
+            {
+                byte version = input.ReadByte();
+                byte[] body;
+                if (bodyLen == 0)
+                    body = [];
+                else
+                {
+                    input.Seek(startPos + 1);
+                    body = new byte[bodyLen];
+                    for (long i = 0; i < bodyLen; i++)
+                        body[i] = input.ReadByte();
+                }
+                return new ReadResult(body, version);
+            }
+        }
+
+        // Envelope fallback: decode through the format chain.
+        input.Seek(startPos);
+        long remaining = input.Length - input.Position;
         byte[] raw = new byte[remaining];
         for (long i = 0; i < remaining; i++)
             raw[i] = input.ReadByte();
@@ -33,26 +191,56 @@ public static class CodecFileHeader
         var seq = new ReadOnlySequence<byte>(raw);
         var reader = new SequenceReader<byte>(seq);
         var ctx = new CodecContext(CodecOptions.Default, CodecRegistry.Default);
-        byte[] body;
+        byte[] decodedBody;
         try
         {
-            body = format.Decode(ref reader, ctx);
+            decodedBody = format.Decode(ref reader, ctx);
         }
         catch (Exception ex) when (ex is not InvalidDataException)
         {
             throw new InvalidDataException("CodecKit file is corrupt or truncated.", ex);
         }
 
-        byte version = raw[0];
-        return new ReadResult(body, version);
+        return new ReadResult(decodedBody, raw[0]);
     }
 
     public static byte ReadVersion(IndexInput input, ICodec<byte[]> format)
+        => ReadVersionAndSkipHeader(input);
+
+    public static byte ReadVersion(IndexInput input)
+        => ReadVersionAndSkipHeader(input);
+
+    public static ReadResult Read(BinaryReader reader, ICodec<byte[]> format)
     {
-        byte version = input.ReadByte();
-        SkipVarInt64(input);
-        return version;
+        var stream = reader.BaseStream;
+        long remaining = stream.Length - stream.Position;
+        if (remaining < 1)
+            throw new InvalidDataException("CodecKit file is truncated: no payload bytes found.");
+        byte[] raw = reader.ReadBytes((int)remaining);
+
+        var seq = new ReadOnlySequence<byte>(raw);
+        var seqReader = new SequenceReader<byte>(seq);
+        var ctx = new CodecContext(CodecOptions.Default, CodecRegistry.Default);
+        byte[] decodedBody;
+        try
+        {
+            decodedBody = format.Decode(ref seqReader, ctx);
+        }
+        catch (Exception ex) when (ex is not InvalidDataException)
+        {
+            throw new InvalidDataException("CodecKit file is corrupt or truncated.", ex);
+        }
+
+        return new ReadResult(decodedBody, raw[0]);
     }
+
+    public static byte ReadVersion(BinaryReader reader, ICodec<byte[]> format)
+        => ReadVersionAndSkipHeader(reader);
+
+    public static byte ReadVersion(BinaryReader reader)
+        => ReadVersionAndSkipHeader(reader);
+
+    // -- Existing Write methods ---------------------------------------------
 
     public static void Write(IndexOutput output, ICodec<byte[]> format, byte[] body)
     {
@@ -61,25 +249,15 @@ public static class CodecFileHeader
         format.Encode(body, writer, ctx);
     }
 
-    /// <summary>
-    /// Writes a codec file envelope with a <see cref="ReadOnlySpan{Byte}"/> body.
-    /// Uses the <see cref="VersionEnvelopeCodec{TBase,TVersion}"/> fast path when
-    /// available, avoiding the intermediate <c>byte[]</c> allocation and scratch staging.
-    /// </summary>
     public static void Write(IndexOutput output, ICodec<byte[]> format, ReadOnlySpan<byte> body)
     {
         using var writer = new Adapters.IndexOutputBuffer(output);
         var ctx = new CodecContext(CodecOptions.Default, CodecRegistry.Default);
 
         if (format is VersionEnvelopeCodec<byte[], byte> envelope)
-        {
             envelope.EncodeSpan(body, writer, ctx);
-        }
         else
-        {
-            // Fallback: allocate byte[] for non-envelope codecs (e.g. WithCompressionCodec).
             format.Encode(body.ToArray(), writer, ctx);
-        }
     }
 
     public static (T Value, byte Version) Read<T>(IndexInput input, ICodec<byte[]> format, ICodec<T> bodyCodec)
@@ -100,57 +278,20 @@ public static class CodecFileHeader
         writer.Write(buf.WrittenSpan);
     }
 
-    /// <summary>
-    /// <see cref="ReadOnlySpan{Byte}"/> overload for the <see cref="BinaryWriter"/> path.
-    /// Uses the <see cref="VersionEnvelopeCodec{TBase,TVersion}"/> fast path when available.
-    /// </summary>
     public static void Write(BinaryWriter writer, ICodec<byte[]> format, ReadOnlySpan<byte> body)
     {
         var buf = new ArrayBufferWriter<byte>(body.Length + 16);
         var ctx = new CodecContext(CodecOptions.Default, CodecRegistry.Default);
 
         if (format is VersionEnvelopeCodec<byte[], byte> envelope)
-        {
             envelope.EncodeSpan(body, buf, ctx);
-        }
         else
-        {
             format.Encode(body.ToArray(), buf, ctx);
-        }
 
         writer.Write(buf.WrittenSpan);
     }
 
-    public static ReadResult Read(BinaryReader reader, ICodec<byte[]> format)
-    {
-        long remaining = reader.BaseStream.Length - reader.BaseStream.Position;
-        if (remaining < 1)
-            throw new InvalidDataException("CodecKit file is truncated: no payload bytes found.");
-        byte[] raw = reader.ReadBytes((int)remaining);
-
-        var seq = new ReadOnlySequence<byte>(raw);
-        var seqReader = new SequenceReader<byte>(seq);
-        var ctx = new CodecContext(CodecOptions.Default, CodecRegistry.Default);
-        byte[] body;
-        try
-        {
-            body = format.Decode(ref seqReader, ctx);
-        }
-        catch (Exception ex) when (ex is not InvalidDataException)
-        {
-            throw new InvalidDataException("CodecKit file is corrupt or truncated.", ex);
-        }
-
-        byte version = raw[0];
-        return new ReadResult(body, version);
-    }
-
-    public static byte ReadVersion(BinaryReader reader, ICodec<byte[]> format)
-    {
-        byte version = reader.ReadByte();
-        SkipVarInt64(reader);
-        return version;
-    }
+    // -- Private helpers ----------------------------------------------------
 
     private static void SkipVarInt64(IndexInput input)
     {
@@ -168,6 +309,45 @@ public static class CodecFileHeader
         {
             byte b = reader.ReadByte();
             if ((b & 0x80) == 0) return;
+        }
+        throw new InvalidDataException("VarInt64 body length is malformed (exceeds 10 bytes).");
+    }
+
+    /// <summary>Reads a ZigZag-encoded VarInt64 (Codec.VarInt64 wire format).</summary>
+    private static long ReadVarInt64(IndexInput input)
+    {
+        ulong result = 0;
+        int shift = 0;
+        for (int i = 0; i < 10; i++)
+        {
+            byte b = input.ReadByte();
+            result |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0)
+            {
+                long signed = (long)(result >> 1);
+                if ((result & 1) != 0) signed = ~signed;
+                return signed;
+            }
+            shift += 7;
+        }
+        throw new InvalidDataException("VarInt64 body length is malformed (exceeds 10 bytes).");
+    }
+
+    private static long ReadVarInt64(BinaryReader reader)
+    {
+        ulong result = 0;
+        int shift = 0;
+        for (int i = 0; i < 10; i++)
+        {
+            byte b = reader.ReadByte();
+            result |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0)
+            {
+                long signed = (long)(result >> 1);
+                if ((result & 1) != 0) signed = ~signed;
+                return signed;
+            }
+            shift += 7;
         }
         throw new InvalidDataException("VarInt64 body length is malformed (exceeds 10 bytes).");
     }

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/BinaryDocValuesReader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/BinaryDocValuesReader.cs
@@ -1,6 +1,7 @@
 using Rowles.LeanCorpus.Codecs.CodecKit;
 using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
 using Rowles.LeanCorpus.Store;
+using System.Collections.Generic;
 
 namespace Rowles.LeanCorpus.Codecs.DocValues;
 
@@ -66,6 +67,62 @@ internal static class BinaryDocValuesReader
         }
 
         return values;
+    }
+
+    internal static IEnumerable<(string Name, IReadOnlyList<byte[]>?[] Values)> EnumerateFields(string filePath)
+    {
+        if (!File.Exists(filePath))
+            yield break;
+
+        using var input = new IndexInput(filePath);
+        byte version = CodecFileHeader.ReadVersionAndSkipHeader(input);
+
+        int fieldCount = input.ReadInt32();
+        for (int f = 0; f < fieldCount; f++)
+        {
+            string fieldName = ReadString(input);
+            int docCount = input.ReadInt32();
+            var starts = new int[docCount + 1];
+            for (int i = 0; i < starts.Length; i++)
+                starts[i] = input.ReadInt32();
+
+            int valueCount = input.ReadInt32();
+            ValidateStarts(starts, valueCount, fieldName);
+
+            var byteOffsets = new int[valueCount + 1];
+            for (int i = 0; i < byteOffsets.Length; i++)
+                byteOffsets[i] = input.ReadInt32();
+            ValidateStarts(byteOffsets, byteOffsets[^1], fieldName);
+
+            var payload = input.ReadBytes(byteOffsets[^1]);
+            var allValues = new byte[valueCount][];
+            for (int i = 0; i < allValues.Length; i++)
+            {
+                int start = byteOffsets[i];
+                int length = byteOffsets[i + 1] - start;
+                var value = new byte[length];
+                Array.Copy(payload, start, value, 0, length);
+                allValues[i] = value;
+            }
+
+            var perDoc = new IReadOnlyList<byte[]>[docCount];
+            for (int docId = 0; docId < docCount; docId++)
+            {
+                int start = starts[docId];
+                int end = starts[docId + 1];
+                if (end == start)
+                {
+                    perDoc[docId] = Array.Empty<byte[]>();
+                    continue;
+                }
+
+                var docValues = new byte[end - start][];
+                Array.Copy(allValues, start, docValues, 0, docValues.Length);
+                perDoc[docId] = docValues;
+            }
+
+            yield return (fieldName, perDoc);
+        }
     }
 
     private static void ValidateStarts(int[] starts, int totalValues, string fieldName)

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/FieldLengthReader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/FieldLengthReader.cs
@@ -47,4 +47,32 @@ internal static class FieldLengthReader
 
         return result;
     }
+
+    internal static IEnumerable<(string Name, int[] Lengths)> EnumerateFields(string filePath)
+    {
+        if (!File.Exists(filePath)) yield break;
+
+        using var input = new IndexInput(filePath);
+        byte version = CodecFileHeader.ReadVersionAndSkipHeader(input);
+
+        int fieldCount = input.ReadInt32();
+
+        for (int f = 0; f < fieldCount; f++)
+        {
+            int nameLen = input.ReadInt32();
+            var nameBytes = new byte[nameLen];
+            for (int b = 0; b < nameLen; b++)
+                nameBytes[b] = input.ReadByte();
+            string fieldName = Encoding.UTF8.GetString(nameBytes);
+
+            int docCount = input.ReadInt32();
+            var lengths = new int[docCount];
+
+            // Current format: VarInt encoding
+            for (int d = 0; d < docCount; d++)
+                lengths[d] = input.ReadVarInt();
+
+            yield return (fieldName, lengths);
+        }
+    }
 }

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/FieldLengthWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/FieldLengthWriter.cs
@@ -13,6 +13,22 @@ namespace Rowles.LeanCorpus.Codecs.DocValues;
 /// </summary>
 internal static class FieldLengthWriter
 {
+
+    internal static void WriteFieldBlock(IBufferWriter<byte> bw, string fieldName, int[] lengths)
+    {
+        int count = lengths.Length;
+        var fieldBytes = Encoding.UTF8.GetBytes(fieldName);
+        bw.WriteInt32(fieldBytes.Length);
+        bw.WriteBytes(fieldBytes);
+        bw.WriteInt32(count);
+
+        for (int i = 0; i < count; i++)
+        {
+            int val = Math.Clamp(lengths[i], 0, ushort.MaxValue);
+            bw.Write7BitEncodedInt(val);
+        }
+    }
+
     internal static void Write(string filePath, IReadOnlyDictionary<string, int[]> fieldTokenCounts, int docCount = -1, bool durable = false)
     {
         var bodyBuf = new ArrayBufferWriter<byte>(4096);
@@ -21,17 +37,7 @@ internal static class FieldLengthWriter
 
         foreach (var (fieldName, counts) in fieldTokenCounts)
         {
-            int count = docCount >= 0 ? docCount : counts.Length;
-            var fieldBytes = Encoding.UTF8.GetBytes(fieldName);
-            bodyBuf.WriteInt32(fieldBytes.Length);
-            bodyBuf.WriteBytes(fieldBytes);
-            bodyBuf.WriteInt32(count);
-
-            for (int i = 0; i < count; i++)
-            {
-                int val = Math.Clamp(counts[i], 0, ushort.MaxValue);
-                bodyBuf.Write7BitEncodedInt(val);
-            }
+            WriteFieldBlock(bodyBuf, fieldName, counts);
         }
 
         using var output = new IndexOutput(filePath, durable);

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/NormsReader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/NormsReader.cs
@@ -21,8 +21,76 @@ internal static class NormsReader
         {
             1 => ReadV1Body(input),
             2 => ReadV2Body(input),
+            3 => ReadV2Body(input), // v3 trailer wrapper, same body format as v2
             _ => throw new NotSupportedException($"Unsupported norms version: {version}")
         };
+    }
+
+    internal static IEnumerable<(string Name, byte[] NormBytes, float[]? Boosts)> EnumerateFields(string filePath)
+    {
+        using var input = new IndexInput(filePath);
+
+        byte version = CodecFileHeader.ReadVersionAndSkipHeader(input);
+
+        int fieldCount;
+        Func<IndexInput, int> readLen, readCount, readBoostCount, readDocId;
+        switch (version)
+        {
+            case 1:
+                fieldCount = input.ReadInt32();
+                readLen = static i => i.ReadInt32();
+                readCount = static i => i.ReadInt32();
+                readBoostCount = static i => i.ReadInt32();
+                readDocId = static i => i.ReadInt32();
+                break;
+            case 2:
+                fieldCount = input.ReadVarInt();
+                readLen = static i => i.ReadVarInt();
+                readCount = static i => i.ReadVarInt();
+                readBoostCount = static i => i.ReadVarInt();
+                readDocId = static i => i.ReadVarInt();
+                break;
+            case 3:
+                fieldCount = input.ReadVarInt();
+                readLen = static i => i.ReadVarInt();
+                readCount = static i => i.ReadVarInt();
+                readBoostCount = static i => i.ReadVarInt();
+                readDocId = static i => i.ReadVarInt();
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported norms version: {version}");
+        }
+
+        for (int f = 0; f < fieldCount; f++)
+        {
+            int fieldNameLen = readLen(input);
+
+            byte[] nameBytes = input.ReadBytes(fieldNameLen);
+            string fieldName = Encoding.UTF8.GetString(nameBytes, 0, fieldNameLen);
+
+            int docCount = readCount(input);
+
+            byte[] norms = input.ReadBytes(docCount);
+
+            int boostCount = readBoostCount(input);
+            if ((uint)boostCount > (uint)docCount)
+                throw new InvalidDataException($"Invalid norms file: boost count {boostCount} exceeds document count {docCount} for field '{fieldName}'.");
+
+            float[]? boosts = null;
+            for (int i = 0; i < boostCount; i++)
+            {
+                int docId = readDocId(input);
+                float boost = input.ReadSingle();
+
+                if ((uint)docId >= (uint)docCount)
+                    throw new InvalidDataException($"Invalid norms file: boost doc ID {docId} is outside field '{fieldName}' document count {docCount}.");
+
+                boosts ??= CreateDefaultBoosts(docCount);
+                boosts[docId] = boost;
+            }
+
+            yield return (fieldName, norms, boosts);
+        }
     }
 
     private static NormsData ReadV1Body(IndexInput input)

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/NormsWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/NormsWriter.cs
@@ -19,6 +19,33 @@ internal static class NormsWriter
     internal static byte QuantiseNorm(float norm)
         => (byte)Math.Clamp(MathF.Round(norm * 255f), 0f, 255f);
 
+
+    internal static void WriteFieldBlock(
+        IBufferWriter<byte> bw,
+        string fieldName,
+        float[] values,
+        float[]? boosts,
+        int docCount)
+    {
+        var fieldBytes = Encoding.UTF8.GetBytes(fieldName);
+        PostingsWriter.WriteVarInt(bw, fieldBytes.Length);
+        bw.WriteBytes(fieldBytes);
+
+        PostingsWriter.WriteVarInt(bw, docCount);
+
+        for (int i = 0; i < docCount; i++)
+            bw.WriteByte(QuantiseNorm(values[i]));
+
+        if (boosts is not null)
+        {
+            WriteDenseBoosts(bw, boosts, docCount);
+        }
+        else
+        {
+            PostingsWriter.WriteVarInt(bw, 0);
+        }
+    }
+
     internal static void Write(
         string filePath,
         IReadOnlyDictionary<string, float[]> fieldNorms,
@@ -34,26 +61,25 @@ internal static class NormsWriter
         foreach (var (fieldName, norms) in fieldNorms)
         {
             int count = docCount >= 0 ? docCount : norms.Length;
-            var fieldBytes = Encoding.UTF8.GetBytes(fieldName);
-            PostingsWriter.WriteVarInt(bodyBuf, fieldBytes.Length);
-            bodyBuf.WriteBytes(fieldBytes);
-
-            PostingsWriter.WriteVarInt(bodyBuf, count);
-
-            for (int i = 0; i < count; i++)
-                bodyBuf.WriteByte(QuantiseNorm(norms[i]));
 
             if (sparseFieldBoosts is not null && sparseFieldBoosts.TryGetValue(fieldName, out var sparseBoosts))
             {
+                // Sparse boosts handled inline; write header + norms then sparse boosts
+                var fieldBytes = Encoding.UTF8.GetBytes(fieldName);
+                PostingsWriter.WriteVarInt(bodyBuf, fieldBytes.Length);
+                bodyBuf.WriteBytes(fieldBytes);
+
+                PostingsWriter.WriteVarInt(bodyBuf, count);
+
+                for (int i = 0; i < count; i++)
+                    bodyBuf.WriteByte(QuantiseNorm(norms[i]));
+
                 WriteSparseBoosts(bodyBuf, sparseBoosts, count);
-            }
-            else if (fieldBoosts is not null && fieldBoosts.TryGetValue(fieldName, out var boosts))
-            {
-                WriteDenseBoosts(bodyBuf, boosts, count);
             }
             else
             {
-                PostingsWriter.WriteVarInt(bodyBuf, 0);
+                float[]? boosts = fieldBoosts is not null && fieldBoosts.TryGetValue(fieldName, out var dense) ? dense : null;
+                WriteFieldBlock(bodyBuf, fieldName, norms, boosts, count);
             }
         }
 

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/NumericDocValues.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/NumericDocValues.cs
@@ -115,7 +115,7 @@ internal static class NumericDocValuesWriter
             output.WriteByte(accum);
     }
 
-    private static void WriteFieldBlock(
+    internal static void WriteFieldBlock(
         IBufferWriter<byte> bw,
         string fieldName,
         double[] values,

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/NumericDocValuesReader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/NumericDocValuesReader.cs
@@ -2,6 +2,7 @@ using Rowles.LeanCorpus.Codecs.CodecKit;
 using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
 using Rowles.LeanCorpus.Store;
 using Rowles.LeanCorpus.Util;
+using System.Collections.Generic;
 
 namespace Rowles.LeanCorpus.Codecs.DocValues;
 
@@ -100,5 +101,90 @@ internal static class NumericDocValuesReader
         }
 
         return (values, presence);
+    }
+
+    internal static IEnumerable<(string Name, double[] Values, RoaringBitmap? Presence)> EnumerateFields(string filePath)
+    {
+        if (!File.Exists(filePath))
+            yield break;
+
+        using var input = new IndexInput(filePath);
+
+        byte version = CodecFileHeader.ReadVersionAndSkipHeader(input);
+        if (version > CodecConstants.NumericDocValuesVersion)
+            throw new InvalidDataException(
+                $"Unsupported numeric doc values (.dvn) format version {version}. " +
+                $"This build supports up to v{CodecConstants.NumericDocValuesVersion}.");
+
+        int fieldCount = input.ReadInt32();
+
+        for (int f = 0; f < fieldCount; f++)
+        {
+            int nameLen = input.ReadVarInt();
+            var nameBytes = new byte[nameLen];
+            for (int b = 0; b < nameLen; b++)
+                nameBytes[b] = input.ReadByte();
+            string fieldName = System.Text.Encoding.UTF8.GetString(nameBytes);
+
+            // Presence block (current format)
+            RoaringBitmap? fieldPresence = null;
+            int presenceByteCount = input.ReadInt32();
+            if (presenceByteCount > 0)
+            {
+                var bitmapBytes = input.ReadBytes(presenceByteCount);
+                using var ms = new System.IO.MemoryStream(bitmapBytes);
+                using var br = new System.IO.BinaryReader(ms);
+                fieldPresence = RoaringBitmap.Deserialise(br);
+            }
+
+            int docCount = input.ReadInt32();
+            long min = input.ReadInt64();
+            int bitsPerValue = input.ReadByte();
+
+            if ((uint)bitsPerValue > 64)
+                throw new InvalidDataException(
+                    $"Invalid bits-per-value {bitsPerValue} for numeric doc values field '{fieldName}'; must be between 0 and 64.");
+
+            if (bitsPerValue > 0)
+            {
+                long expectedPackedBytes = ((long)bitsPerValue * docCount + 7) / 8;
+                if (input.Position + expectedPackedBytes > input.Length)
+                    throw new InvalidDataException(
+                        $"Numeric doc values field '{fieldName}' declares {bitsPerValue} bits per value for {docCount} documents, but the file does not contain the expected packed data.");
+            }
+
+            var fieldValues = new double[docCount];
+            if (bitsPerValue == 0)
+            {
+                double constVal = BitConverter.Int64BitsToDouble(min);
+                Array.Fill(fieldValues, constVal);
+            }
+            else
+            {
+                byte accum = 0;
+                int accBits = 0;
+                for (int i = 0; i < docCount; i++)
+                {
+                    ulong val = 0;
+                    int collected = 0;
+                    while (collected < bitsPerValue)
+                    {
+                        if (accBits == 0)
+                        {
+                            accum = input.ReadByte();
+                            accBits = 8;
+                        }
+                        int take = Math.Min(bitsPerValue - collected, accBits);
+                        val |= ((ulong)(accum & ((1 << take) - 1))) << collected;
+                        accum >>= take;
+                        accBits -= take;
+                        collected += take;
+                    }
+                    fieldValues[i] = BitConverter.Int64BitsToDouble((long)((ulong)min + val));
+                }
+            }
+
+            yield return (fieldName, fieldValues, fieldPresence);
+        }
     }
 }

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/SortedDocValues.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/SortedDocValues.cs
@@ -28,7 +28,7 @@ internal static class SortedDocValuesWriter
         CodecFileHeader.Write(output, CodecFormats.SortedDocValues, bodyBuf.WrittenSpan);
     }
 
-    private static void WriteFieldBlock(IBufferWriter<byte> bw, string fieldName, string?[] values, int docCount)
+    internal static void WriteFieldBlock(IBufferWriter<byte> bw, string fieldName, string?[] values, int docCount)
     {
         bw.WriteString(fieldName);
 

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/SortedDocValuesReader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/SortedDocValuesReader.cs
@@ -2,6 +2,7 @@ using Rowles.LeanCorpus.Codecs.CodecKit;
 using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
 using Rowles.LeanCorpus.Store;
 using Rowles.LeanCorpus.Util;
+using System.Collections.Generic;
 
 namespace Rowles.LeanCorpus.Codecs.DocValues;
 
@@ -95,5 +96,85 @@ internal static class SortedDocValuesReader
         }
 
         return (values, presence);
+    }
+
+    internal static IEnumerable<(string Name, string?[] Values)> EnumerateFields(string filePath)
+    {
+        if (!File.Exists(filePath))
+            yield break;
+
+        using var input = new IndexInput(filePath);
+
+        byte version = CodecFileHeader.ReadVersionAndSkipHeader(input);
+
+        int fieldCount = input.ReadInt32();
+
+        for (int f = 0; f < fieldCount; f++)
+        {
+            int nameLen = input.ReadVarInt();
+            var nameBytes = new byte[nameLen];
+            for (int b = 0; b < nameLen; b++)
+                nameBytes[b] = input.ReadByte();
+            string fieldName = System.Text.Encoding.UTF8.GetString(nameBytes);
+
+            // Presence block (current format)
+            RoaringBitmap? fieldPresence = null;
+            int presenceByteCount = input.ReadInt32();
+            if (presenceByteCount > 0)
+            {
+                var bitmapBytes = input.ReadBytes(presenceByteCount);
+                using var ms = new System.IO.MemoryStream(bitmapBytes);
+                using var br = new System.IO.BinaryReader(ms);
+                fieldPresence = RoaringBitmap.Deserialise(br);
+            }
+
+            int docCount = input.ReadInt32();
+            int ordCount = input.ReadInt32();
+
+            var ordTable = new string[ordCount];
+            for (int o = 0; o < ordCount; o++)
+            {
+                int len = input.ReadVarInt();
+                var bytes = new byte[len];
+                for (int b = 0; b < len; b++)
+                    bytes[b] = input.ReadByte();
+                ordTable[o] = System.Text.Encoding.UTF8.GetString(bytes);
+            }
+
+            int bitsPerOrd = input.ReadByte();
+            if (bitsPerOrd > 63)
+                throw new InvalidDataException(
+                    $"Sorted DocValues field '{fieldName}' has bitsPerOrd={bitsPerOrd}, max is 63.");
+
+            var fieldValues = new string[docCount];
+
+            if (bitsPerOrd == 0)
+            {
+                Array.Fill(fieldValues, ordTable.Length > 0 ? ordTable[0] : string.Empty);
+            }
+            else
+            {
+                ulong mask = (1UL << bitsPerOrd) - 1;
+                ulong buffer = 0;
+                int bitsInBuffer = 0;
+                for (int i = 0; i < docCount; i++)
+                {
+                    while (bitsInBuffer < bitsPerOrd)
+                    {
+                        buffer |= (ulong)input.ReadByte() << bitsInBuffer;
+                        bitsInBuffer += 8;
+                    }
+                    int ord = (int)(buffer & mask);
+                    buffer >>= bitsPerOrd;
+                    bitsInBuffer -= bitsPerOrd;
+                    if ((uint)ord >= (uint)ordTable.Length)
+                        throw new InvalidDataException(
+                            $"Sorted DocValues field '{fieldName}' has ordinal {ord} but ordTable has {ordTable.Length} entries.");
+                    fieldValues[i] = ordTable[ord];
+                }
+            }
+
+            yield return (fieldName, fieldValues);
+        }
     }
 }

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/SortedNumericDocValuesReader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/SortedNumericDocValuesReader.cs
@@ -1,6 +1,7 @@
 using Rowles.LeanCorpus.Store;
 using Rowles.LeanCorpus.Codecs.CodecKit;
 using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
+using System.Collections.Generic;
 
 namespace Rowles.LeanCorpus.Codecs.DocValues;
 
@@ -51,6 +52,47 @@ internal static class SortedNumericDocValuesReader
         }
 
         return values;
+    }
+
+    internal static IEnumerable<(string Name, IReadOnlyList<double>?[] Values)> EnumerateFields(string filePath)
+    {
+        if (!File.Exists(filePath))
+            yield break;
+
+        using var input = new IndexInput(filePath);
+        byte version = CodecFileHeader.ReadVersionAndSkipHeader(input);
+
+        int fieldCount = input.ReadInt32();
+        for (int f = 0; f < fieldCount; f++)
+        {
+            string fieldName = ReadString(input);
+            int docCount = input.ReadInt32();
+            var starts = new int[docCount + 1];
+            for (int i = 0; i < starts.Length; i++)
+                starts[i] = input.ReadInt32();
+
+            int valueCount = input.ReadInt32();
+            ValidateStarts(starts, valueCount, fieldName);
+            var flattened = ReadPackedDoubles(input, valueCount);
+
+            var perDoc = new IReadOnlyList<double>[docCount];
+            for (int docId = 0; docId < docCount; docId++)
+            {
+                int start = starts[docId];
+                int end = starts[docId + 1];
+                if (end == start)
+                {
+                    perDoc[docId] = Array.Empty<double>();
+                    continue;
+                }
+
+                var docValues = new double[end - start];
+                Array.Copy(flattened, start, docValues, 0, docValues.Length);
+                perDoc[docId] = docValues;
+            }
+
+            yield return (fieldName, perDoc);
+        }
     }
 
     private static double[] ReadPackedDoubles(IndexInput input, int valueCount)

--- a/src/core/Rowles.LeanCorpus/Codecs/DocValues/SortedSetDocValuesReader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/DocValues/SortedSetDocValuesReader.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Rowles.LeanCorpus.Codecs.CodecKit;
 using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
 using Rowles.LeanCorpus.Store;
+using System.Collections.Generic;
 
 namespace Rowles.LeanCorpus.Codecs.DocValues;
 
@@ -66,6 +67,61 @@ internal static class SortedSetDocValuesReader
         }
 
         return values;
+    }
+
+    internal static IEnumerable<(string Name, IReadOnlyList<string>?[] Values)> EnumerateFields(string filePath)
+    {
+        if (!File.Exists(filePath))
+            yield break;
+
+        using var input = new IndexInput(filePath);
+        byte version = CodecFileHeader.ReadVersionAndSkipHeader(input);
+
+        int fieldCount = input.ReadInt32();
+        for (int f = 0; f < fieldCount; f++)
+        {
+            string fieldName = ReadString(input);
+            int docCount = input.ReadInt32();
+            int ordCount = input.ReadInt32();
+            var ordTable = new string[ordCount];
+            for (int i = 0; i < ordTable.Length; i++)
+                ordTable[i] = ReadString(input);
+
+            var starts = new int[docCount + 1];
+            for (int i = 0; i < starts.Length; i++)
+                starts[i] = input.ReadInt32();
+
+            int totalOrdinals = input.ReadInt32();
+            ValidateStarts(starts, totalOrdinals, fieldName);
+
+            var ordinals = new int[totalOrdinals];
+            for (int i = 0; i < ordinals.Length; i++)
+            {
+                int ord = input.ReadVarInt();
+                if ((uint)ord >= (uint)ordTable.Length)
+                    throw new InvalidDataException($"Invalid sorted-set DocValues ordinal {ord} for field '{fieldName}'.");
+                ordinals[i] = ord;
+            }
+
+            var perDoc = new IReadOnlyList<string>[docCount];
+            for (int docId = 0; docId < docCount; docId++)
+            {
+                int start = starts[docId];
+                int end = starts[docId + 1];
+                if (end == start)
+                {
+                    perDoc[docId] = Array.Empty<string>();
+                    continue;
+                }
+
+                var docValues = new string[end - start];
+                for (int i = 0; i < docValues.Length; i++)
+                    docValues[i] = ordTable[ordinals[start + i]];
+                perDoc[docId] = docValues;
+            }
+
+            yield return (fieldName, perDoc);
+        }
     }
 
     private static void ValidateStarts(int[] starts, int totalValues, string fieldName)

--- a/src/core/Rowles.LeanCorpus/Codecs/Postings/PostingsFileHeader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/Postings/PostingsFileHeader.cs
@@ -6,12 +6,14 @@ namespace Rowles.LeanCorpus.Codecs.Postings;
 /// <summary>
 /// Manual header read/write for postings files.
 /// v1 used the CodecKit envelope: [version:byte][VarInt64 bodyLen][body].
-/// v2 streams directly: [version:byte][body].
+/// v2 streams directly: [version:byte][body] (ADR008 custom header).
+/// v3 uses the CodecKit trailer: [version:byte][body][bodyLen:int64].
 /// </summary>
 internal static class PostingsFileHeader
 {
     internal const byte V1 = 1;
     internal const byte V2 = 2;
+    internal const byte V3 = 3;
 
     /// <summary>
     /// Reads the version byte and skips any v1-only VarInt64 length prefix.
@@ -38,14 +40,6 @@ internal static class PostingsFileHeader
             SkipVarInt64(input);
 
         return version;
-    }
-
-    /// <summary>
-    /// Writes the v2 header: a single version byte. Body follows immediately.
-    /// </summary>
-    internal static void WriteV2Header(IndexOutput output)
-    {
-        output.WriteByte(V2);
     }
 
     private static void SkipVarInt64(BinaryReader reader)

--- a/src/core/Rowles.LeanCorpus/Codecs/Postings/PostingsWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/Postings/PostingsWriter.cs
@@ -1,3 +1,4 @@
+using Rowles.LeanCorpus.Codecs.CodecKit;
 using System.Buffers;
 using Rowles.LeanCorpus.Store;
 
@@ -25,7 +26,7 @@ internal static class PostingsWriter
         }
 
         using var output = new IndexOutput(filePath, durable: true);
-        PostingsFileHeader.WriteV2Header(output);
+        using var scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.PostingsVersion);
         output.WriteBytes(bodyBuf.WrittenSpan);
     }
 

--- a/src/core/Rowles.LeanCorpus/Codecs/Postings/StreamingPostingsMerger.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/Postings/StreamingPostingsMerger.cs
@@ -1,3 +1,4 @@
+using Rowles.LeanCorpus.Codecs.CodecKit;
 using System.Buffers;
 using Rowles.LeanCorpus.Codecs.TermDictionary;
 using Rowles.LeanCorpus.Store;
@@ -50,9 +51,9 @@ internal static class StreamingPostingsMerger
                 }
             }
 
-            // Write v2 header directly to final output — no temp file, no envelope.
+            // Write v3 header via CodecKit trailer format.
             using var posOutput = new IndexOutput(posOutputPath, durable: true, dropPageCache: true);
-            PostingsFileHeader.WriteV2Header(posOutput);
+            using var scope = CodecFileHeader.BeginStreamingWrite(posOutput, CodecConstants.PostingsVersion);
             using var blockWriter = new BlockPostingsWriter(posOutput);
 
             var sortedTerms = new List<string>();

--- a/src/core/Rowles.LeanCorpus/Codecs/StoredFields/StoredFieldsFileHeader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/StoredFields/StoredFieldsFileHeader.cs
@@ -6,12 +6,14 @@ namespace Rowles.LeanCorpus.Codecs.StoredFields;
 /// <summary>
 /// Manual header read/write for stored-fields files.
 /// v1 used the CodecKit envelope: [version:byte][VarInt64 bodyLen][body].
-/// v2 streams directly: [version:byte][body] with body fields read by the caller.
+/// v2 streams directly: [version:byte][body] (ADR008 custom header).
+/// v3 uses the CodecKit trailer: [version:byte][body][bodyLen:int64].
 /// </summary>
 internal static class StoredFieldsFileHeader
 {
     internal const byte V1 = 1;
     internal const byte V2 = 2;
+    internal const byte V3 = 3;
 
     /// <summary>Size of the v2 .fdt header: version + blockSize + compression.</summary>
     internal const int V2FdtHeaderSize = sizeof(byte) + sizeof(int) + sizeof(byte);
@@ -33,6 +35,19 @@ internal static class StoredFieldsFileHeader
         return version;
     }
 
+    /// <summary>
+    /// Writes the v3 .fdx header: a single version byte followed by block metadata.
+    /// Body format is identical to v2; only the version byte changes (v2 to v3).
+    /// </summary>
+    internal static void WriteV3FdxHeader(IndexOutput output, int blockSize, int docCount, int blockCount)
+    {
+        output.WriteByte(V3);
+        output.WriteInt32(blockSize);
+        output.WriteInt32(docCount);
+        output.WriteInt32(blockCount);
+    }
+
+    // Deprecated by v3 trailer; kept until Phase C cutover.
     internal static void WriteV2FdtHeader(IndexOutput output, int blockSize, FieldCompressionPolicy compression)
     {
         output.WriteByte(V2);
@@ -40,6 +55,7 @@ internal static class StoredFieldsFileHeader
         output.WriteByte((byte)compression);
     }
 
+    // Deprecated by v3 trailer; kept until Phase C cutover.
     internal static void WriteV2FdxHeader(IndexOutput output, int blockSize, int docCount, int blockCount)
     {
         output.WriteByte(V2);

--- a/src/core/Rowles.LeanCorpus/Codecs/StoredFields/StoredFieldsReader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/StoredFields/StoredFieldsReader.cs
@@ -70,11 +70,11 @@ internal sealed class StoredFieldsReader : IDisposable
         using var fdxReader = new BinaryReader(fdxStream, System.Text.Encoding.UTF8, leaveOpen: false);
 
         byte fdxVersion = StoredFieldsFileHeader.ReadVersion(fdxReader);
-        if (fdxVersion > StoredFieldsFileHeader.V2)
+        if (fdxVersion > StoredFieldsFileHeader.V3)
         {
             throw new InvalidDataException(
                 $"Unsupported stored fields index (.fdx) format version {fdxVersion}. " +
-                $"This build supports up to version {StoredFieldsFileHeader.V2}.");
+                $"This build supports up to version {StoredFieldsFileHeader.V3}.");
         }
 
         int fdxBlockSize = fdxReader.ReadInt32();
@@ -91,11 +91,11 @@ internal sealed class StoredFieldsReader : IDisposable
 
         fs.Seek(0, SeekOrigin.Begin);
         byte fdtVersion = StoredFieldsFileHeader.ReadVersion(reader);
-        if (fdtVersion > StoredFieldsFileHeader.V2)
+        if (fdtVersion > StoredFieldsFileHeader.V3)
         {
             throw new InvalidDataException(
                 $"Unsupported stored fields data (.fdt) format version {fdtVersion}. " +
-                $"This build supports up to version {StoredFieldsFileHeader.V2}.");
+                $"This build supports up to version {StoredFieldsFileHeader.V3}.");
         }
 
         int fdtBlockSize = reader.ReadInt32();

--- a/src/core/Rowles.LeanCorpus/Codecs/StoredFields/StoredFieldsStreamWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/StoredFields/StoredFieldsStreamWriter.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
 using System.Text;
+using Rowles.LeanCorpus.Codecs;
+using Rowles.LeanCorpus.Codecs.CodecKit;
 using Rowles.LeanCorpus.Store;
 
 namespace Rowles.LeanCorpus.Codecs.StoredFields;
@@ -14,6 +16,7 @@ internal sealed class StoredFieldsStreamWriter : IDisposable
     private const int DefaultBlockSize = 16;
 
     private readonly IndexOutput _fdtOutput;
+    private readonly CodecFileHeader.StreamingWriteScope _fdtScope;
     private readonly string _fdtPath;
     private readonly string _fdxPath;
     private readonly int _blockSize;
@@ -39,7 +42,9 @@ internal sealed class StoredFieldsStreamWriter : IDisposable
         _blockOffsets = new List<long>();
         _intraOffsets = new List<int>(blockSize);
 
-        StoredFieldsFileHeader.WriteV2FdtHeader(_fdtOutput, blockSize, compression);
+        _fdtScope = CodecFileHeader.BeginStreamingWrite(_fdtOutput, CodecConstants.StoredFieldsVersion);
+        _fdtScope.Output.WriteInt32(blockSize);
+        _fdtScope.Output.WriteByte((byte)compression);
     }
 
     internal void AddDocument(IReadOnlyDictionary<string, IReadOnlyList<StoredFieldValue>> fields)
@@ -123,6 +128,7 @@ internal sealed class StoredFieldsStreamWriter : IDisposable
         try
         {
             FlushBlock();
+            _fdtScope.Dispose();
         }
         finally
         {
@@ -132,7 +138,7 @@ internal sealed class StoredFieldsStreamWriter : IDisposable
         try
         {
             using var fdxOutput = new IndexOutput(_fdxPath, durable: true);
-            StoredFieldsFileHeader.WriteV2FdxHeader(fdxOutput, _blockSize, _docCount, _blockOffsets.Count);
+            StoredFieldsFileHeader.WriteV3FdxHeader(fdxOutput, _blockSize, _docCount, _blockOffsets.Count);
             foreach (var offset in _blockOffsets)
                 fdxOutput.WriteInt64(offset);
         }

--- a/src/core/Rowles.LeanCorpus/Codecs/StoredFields/StoredFieldsWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/StoredFields/StoredFieldsWriter.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
 using System.Text;
+using Rowles.LeanCorpus.Codecs;
+using Rowles.LeanCorpus.Codecs.CodecKit;
 using Rowles.LeanCorpus.Store;
 
 namespace Rowles.LeanCorpus.Codecs.StoredFields;
@@ -23,7 +25,9 @@ internal static class StoredFieldsWriter
         int docCount = docStarts.Count;
 
         using var fdtOutput = new IndexOutput(fdtPath, durable: true);
-        StoredFieldsFileHeader.WriteV2FdtHeader(fdtOutput, blockSize, compression);
+        using var fdtScope = CodecFileHeader.BeginStreamingWrite(fdtOutput, CodecConstants.StoredFieldsVersion);
+        fdtScope.Output.WriteInt32(blockSize);
+        fdtScope.Output.WriteByte((byte)compression);
 
         var blockOffsets = new List<long>();
         var rawBuf = new ArrayBufferWriter<byte>(4096);
@@ -138,7 +142,9 @@ internal static class StoredFieldsWriter
         FieldCompressionPolicy compression = FieldCompressionPolicy.Deflate)
     {
         using var fdtOutput = new IndexOutput(fdtPath, durable: true);
-        StoredFieldsFileHeader.WriteV2FdtHeader(fdtOutput, blockSize, compression);
+        using var fdtScope = CodecFileHeader.BeginStreamingWrite(fdtOutput, CodecConstants.StoredFieldsVersion);
+        fdtScope.Output.WriteInt32(blockSize);
+        fdtScope.Output.WriteByte((byte)compression);
 
         var blockOffsets = new List<long>();
         var rawBuf = new ArrayBufferWriter<byte>(4096);
@@ -191,7 +197,7 @@ internal static class StoredFieldsWriter
     private static void WriteFdx(string fdxPath, int blockSize, int docCount, List<long> blockOffsets)
     {
         using var fdxOutput = new IndexOutput(fdxPath, durable: true);
-        StoredFieldsFileHeader.WriteV2FdxHeader(fdxOutput, blockSize, docCount, blockOffsets.Count);
+        StoredFieldsFileHeader.WriteV3FdxHeader(fdxOutput, blockSize, docCount, blockOffsets.Count);
         foreach (var offset in blockOffsets)
             fdxOutput.WriteInt64(offset);
     }

--- a/src/core/Rowles.LeanCorpus/Codecs/TermDictionary/TermDictionaryReader.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/TermDictionary/TermDictionaryReader.cs
@@ -311,6 +311,13 @@ internal sealed class TermDictionaryReader : IDisposable
         return results;
     }
 
+    /// <summary>Lazily enumerates all (term, offset) pairs in sorted byte order.</summary>
+    internal IEnumerable<(string Term, long Offset)> EnumerateTerms()
+    {
+        foreach (var (key, output) in _fst.EnumerateAll())
+            yield return (Encoding.UTF8.GetString(key), output);
+    }
+
     public List<(string Term, long Offset)> GetTermsInRange(
         string fieldPrefix, string? lower, string? upper, bool includeLower = true, bool includeUpper = true)
     {

--- a/src/core/Rowles.LeanCorpus/Codecs/TermVectors/TermVectorsStreamWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/TermVectors/TermVectorsStreamWriter.cs
@@ -1,6 +1,4 @@
-using System.Buffers;
 using Rowles.LeanCorpus.Codecs.CodecKit;
-using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
 using Rowles.LeanCorpus.Store;
 
 namespace Rowles.LeanCorpus.Codecs.TermVectors;
@@ -14,7 +12,8 @@ internal sealed class TermVectorsStreamWriter : IDisposable
 {
     private readonly string _tvdPath;
     private readonly string _tvxPath;
-    private readonly ArrayBufferWriter<byte> _tvdBuf;
+    private readonly IndexOutput _tvdOutput;
+    private readonly CodecFileHeader.StreamingWriteScope _tvdScope;
     private readonly List<long> _offsets;
     private bool _disposed;
 
@@ -22,31 +21,32 @@ internal sealed class TermVectorsStreamWriter : IDisposable
     {
         _tvdPath = tvdPath;
         _tvxPath = tvxPath;
-        _tvdBuf = new ArrayBufferWriter<byte>(4096);
+        _tvdOutput = new IndexOutput(tvdPath, durable: true);
+        _tvdScope = CodecFileHeader.BeginStreamingWrite(_tvdOutput, CodecConstants.TermVectorsVersion);
         _offsets = new List<long>();
     }
 
     internal void AddDocument(IReadOnlyDictionary<string, List<TermVectorEntry>>? fields)
     {
-        _offsets.Add(_tvdBuf.WrittenCount);
+        _offsets.Add(_tvdScope.Output.Position);
         if (fields is null)
         {
-            _tvdBuf.WriteInt32(0);
+            _tvdScope.Output.WriteInt32(0);
             return;
         }
 
-        _tvdBuf.WriteInt32(fields.Count);
+        _tvdScope.Output.WriteInt32(fields.Count);
         foreach (var (fieldName, entries) in fields)
         {
-            _tvdBuf.WriteString(fieldName);
-            _tvdBuf.WriteInt32(entries.Count);
+            _tvdScope.Output.WriteString(fieldName);
+            _tvdScope.Output.WriteInt32(entries.Count);
             foreach (var entry in entries)
             {
-                _tvdBuf.WriteString(entry.Term);
-                _tvdBuf.WriteInt32(entry.Freq);
-                _tvdBuf.WriteInt32(entry.Positions.Length);
+                _tvdScope.Output.WriteString(entry.Term);
+                _tvdScope.Output.WriteInt32(entry.Freq);
+                _tvdScope.Output.WriteInt32(entry.Positions.Length);
                 foreach (var pos in entry.Positions)
-                    _tvdBuf.WriteInt32(pos);
+                    _tvdScope.Output.WriteInt32(pos);
                 WritePayloads(entry);
                 WriteOffsets(entry);
             }
@@ -58,48 +58,38 @@ internal sealed class TermVectorsStreamWriter : IDisposable
         if (_disposed) return;
         _disposed = true;
 
-        long tvdBodyLength = _tvdBuf.WrittenCount;
+        // Finish .tvd: dispose scope (writes trailer), then dispose the underlying output.
+        _tvdScope.Dispose();
+        _tvdOutput.Dispose();
 
-        long headerSize;
-        using (var tvdOutput = new IndexOutput(_tvdPath, durable: true))
-        {
-            CodecFileHeader.Write(tvdOutput, CodecFormats.TermVectors, _tvdBuf.WrittenSpan);
-            headerSize = tvdOutput.Position - tvdBodyLength;
-        }
-
-        // Re-base body-relative offsets to file-absolute positions.
-        for (int i = 0; i < _offsets.Count; i++)
-            _offsets[i] += headerSize;
-
-        var tvxBodyBuf = new ArrayBufferWriter<byte>(1024);
-        tvxBodyBuf.WriteInt32(_offsets.Count);
-        foreach (var off in _offsets)
-            tvxBodyBuf.WriteInt64(off);
-
+        // Write .tvx offset index via streaming scope.
         using var tvxOutput = new IndexOutput(_tvxPath, durable: true);
-        CodecFileHeader.Write(tvxOutput, CodecFormats.TermVectors, tvxBodyBuf.WrittenSpan);
+        using var tvxScope = CodecFileHeader.BeginStreamingWrite(tvxOutput, CodecConstants.TermVectorsVersion);
+        tvxScope.Output.WriteInt32(_offsets.Count);
+        foreach (var off in _offsets)
+            tvxScope.Output.WriteInt64(off);
     }
 
     private void WriteOffsets(TermVectorEntry entry)
     {
         bool hasOffsets = entry.StartOffsets is { Length: > 0 } && entry.EndOffsets is { Length: > 0 };
-        _tvdBuf.WriteByte(hasOffsets ? (byte)1 : (byte)0);
+        _tvdScope.Output.WriteByte(hasOffsets ? (byte)1 : (byte)0);
         if (!hasOffsets) return;
 
         if (entry.StartOffsets!.Length != entry.Positions.Length || entry.EndOffsets!.Length != entry.Positions.Length)
             throw new InvalidDataException($"Term vector offset count for term '{entry.Term}' must match the position count.");
 
         for (int i = 0; i < entry.StartOffsets.Length; i++)
-            _tvdBuf.WriteInt32(entry.StartOffsets[i]);
+            _tvdScope.Output.WriteInt32(entry.StartOffsets[i]);
         for (int i = 0; i < entry.EndOffsets.Length; i++)
-            _tvdBuf.WriteInt32(entry.EndOffsets[i]);
+            _tvdScope.Output.WriteInt32(entry.EndOffsets[i]);
     }
 
     private void WritePayloads(TermVectorEntry entry)
     {
         bool hasPayloads = entry.Payloads is { Length: > 0 } payloads
             && payloads.Any(static payload => payload is { Length: > 0 });
-        _tvdBuf.WriteByte(hasPayloads ? (byte)1 : (byte)0);
+        _tvdScope.Output.WriteByte(hasPayloads ? (byte)1 : (byte)0);
 
         if (!hasPayloads)
             return;
@@ -110,9 +100,9 @@ internal sealed class TermVectorsStreamWriter : IDisposable
         for (int i = 0; i < entry.Payloads.Length; i++)
         {
             var payload = entry.Payloads[i];
-            _tvdBuf.WriteInt32(payload?.Length ?? 0);
+            _tvdScope.Output.WriteInt32(payload?.Length ?? 0);
             if (payload is { Length: > 0 })
-                _tvdBuf.WriteBytes(payload);
+                _tvdScope.Output.WriteBytes(payload);
         }
     }
 }

--- a/src/core/Rowles.LeanCorpus/Codecs/TermVectors/TermVectorsWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Codecs/TermVectors/TermVectorsWriter.cs
@@ -1,12 +1,10 @@
-using System.Buffers;
 using Rowles.LeanCorpus.Codecs.CodecKit;
-using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
 using Rowles.LeanCorpus.Store;
 
 namespace Rowles.LeanCorpus.Codecs.TermVectors;
 
 /// <summary>
-/// Writes per-document term vectors to .tvd (data) and .tvx (offset index) files (v2 format).
+/// Writes per-document term vectors to .tvd (data) and .tvx (offset index) files (v3 format).
 /// Format: .tvx: [docCount:int32] [long[] offsets into .tvd]
 ///         .tvd per doc: [fieldCount:int32] per field: [fieldName:string] [termCount:int32]
 ///              per term: [term:string] [freq:int32] [posCount:int32] [positions:int32[]]
@@ -14,89 +12,81 @@ namespace Rowles.LeanCorpus.Codecs.TermVectors;
 /// </summary>
 /// <remarks>
 /// <para>Version history:</para>
-/// <para>v1 — per-term layout ended after payloads. No offset data.</para>
-/// <para>v2 — adds [hasOffsets:bool] with conditional [startOffsets:int32[]] [endOffsets:int32[]] for highlighters.</para>
+/// <para>v1: per-term layout ended after payloads.  No offset data.</para>
+/// <para>v2: adds [hasOffsets:bool] with conditional [startOffsets:int32[]] [endOffsets:int32[]] for highlighters.</para>
+/// <para>v3: CodecKit trailer format (streaming write, 8-byte Int64 trailer).</para>
 /// </remarks>
 internal static class TermVectorsWriter
 {
     public static void Write(string tvdPath, string tvxPath,
         IReadOnlyList<Dictionary<string, List<TermVectorEntry>>?> docs)
     {
-        // Buffer .tvd body and track body-relative offsets.
-        var bodyOffsets = new long[docs.Count];
-        var bodyBuf = new ArrayBufferWriter<byte>(4096);
-        for (int d = 0; d < docs.Count; d++)
+        // Track file-absolute offsets; BeginStreamingWrite writes the version byte
+        // at position 0, so body starts at position 1.  Offsets are thus file-absolute.
+        var offsets = new long[docs.Count];
+
+        // Write .tvd data via streaming scope (trailer written on dispose).
+        using (var tvdOutput = new IndexOutput(tvdPath, durable: true))
+        using (var tvdScope = CodecFileHeader.BeginStreamingWrite(tvdOutput, CodecConstants.TermVectorsVersion))
         {
-            bodyOffsets[d] = bodyBuf.WrittenCount;
-            var fields = docs[d];
-            if (fields is null)
+            for (int d = 0; d < docs.Count; d++)
             {
-                bodyBuf.WriteInt32(0);
-                continue;
-            }
-            bodyBuf.WriteInt32(fields.Count);
-            foreach (var (fieldName, entries) in fields)
-            {
-                bodyBuf.WriteString(fieldName);
-                bodyBuf.WriteInt32(entries.Count);
-                foreach (var entry in entries)
+                offsets[d] = tvdScope.Output.Position;
+                var fields = docs[d];
+                if (fields is null)
                 {
-                    bodyBuf.WriteString(entry.Term);
-                    bodyBuf.WriteInt32(entry.Freq);
-                    bodyBuf.WriteInt32(entry.Positions.Length);
-                    foreach (var pos in entry.Positions)
-                        bodyBuf.WriteInt32(pos);
-                    WritePayloads(bodyBuf, entry);
-                    WriteOffsets(bodyBuf, entry);
+                    tvdScope.Output.WriteInt32(0);
+                    continue;
+                }
+                tvdScope.Output.WriteInt32(fields.Count);
+                foreach (var (fieldName, entries) in fields)
+                {
+                    tvdScope.Output.WriteString(fieldName);
+                    tvdScope.Output.WriteInt32(entries.Count);
+                    foreach (var entry in entries)
+                    {
+                        tvdScope.Output.WriteString(entry.Term);
+                        tvdScope.Output.WriteInt32(entry.Freq);
+                        tvdScope.Output.WriteInt32(entry.Positions.Length);
+                        foreach (var pos in entry.Positions)
+                            tvdScope.Output.WriteInt32(pos);
+                        WritePayloads(tvdScope.Output, entry);
+                        WriteOffsets(tvdScope.Output, entry);
+                    }
                 }
             }
         }
-        long tvdBodyLength = bodyBuf.WrittenCount;
 
-        // Write .tvd file and capture envelope header size for offset computation.
-        long headerSize;
-        using (var tvdOutput = new IndexOutput(tvdPath, durable: true))
+        // Write .tvx offset index via streaming scope.
+        using (var tvxOutput = new IndexOutput(tvxPath, durable: true))
+        using (var tvxScope = CodecFileHeader.BeginStreamingWrite(tvxOutput, CodecConstants.TermVectorsVersion))
         {
-            CodecFileHeader.Write(tvdOutput, CodecFormats.TermVectors, bodyBuf.WrittenSpan);
-            headerSize = tvdOutput.Position - tvdBodyLength;
+            tvxScope.Output.WriteInt32(docs.Count);
+            foreach (var offset in offsets)
+                tvxScope.Output.WriteInt64(offset);
         }
-
-        // Compute file-absolute offsets: envelope header size + body-relative offset.
-        var offsets = new long[docs.Count];
-        for (int d = 0; d < docs.Count; d++)
-            offsets[d] = headerSize + bodyOffsets[d];
-
-        // Buffer .tvx body.
-        var tvxBodyBuf = new ArrayBufferWriter<byte>(1024);
-        tvxBodyBuf.WriteInt32(docs.Count);
-        foreach (var offset in offsets)
-            tvxBodyBuf.WriteInt64(offset);
-
-        // Write .tvx index.
-        using var tvxOutput = new IndexOutput(tvxPath, durable: true);
-        CodecFileHeader.Write(tvxOutput, CodecFormats.TermVectors, tvxBodyBuf.WrittenSpan);
     }
 
-
-    private static void WriteOffsets(IBufferWriter<byte> writer, TermVectorEntry entry)
+    private static void WriteOffsets(IndexOutput output, TermVectorEntry entry)
     {
         bool hasOffsets = entry.StartOffsets is { Length: > 0 } && entry.EndOffsets is { Length: > 0 };
-        writer.WriteByte(hasOffsets ? (byte)1 : (byte)0);
+        output.WriteByte(hasOffsets ? (byte)1 : (byte)0);
         if (!hasOffsets) return;
 
         if (entry.StartOffsets!.Length != entry.Positions.Length || entry.EndOffsets!.Length != entry.Positions.Length)
             throw new InvalidDataException($"Term vector offset count for term '{entry.Term}' must match the position count.");
 
         for (int i = 0; i < entry.StartOffsets.Length; i++)
-            writer.WriteInt32(entry.StartOffsets[i]);
+            output.WriteInt32(entry.StartOffsets[i]);
         for (int i = 0; i < entry.EndOffsets.Length; i++)
-            writer.WriteInt32(entry.EndOffsets[i]);
+            output.WriteInt32(entry.EndOffsets[i]);
     }
-    private static void WritePayloads(IBufferWriter<byte> writer, TermVectorEntry entry)
+
+    private static void WritePayloads(IndexOutput output, TermVectorEntry entry)
     {
         bool hasPayloads = entry.Payloads is { Length: > 0 } payloads
             && payloads.Any(static payload => payload is { Length: > 0 });
-        writer.WriteByte(hasPayloads ? (byte)1 : (byte)0);
+        output.WriteByte(hasPayloads ? (byte)1 : (byte)0);
 
         if (!hasPayloads)
             return;
@@ -107,9 +97,9 @@ internal static class TermVectorsWriter
         for (int i = 0; i < entry.Payloads.Length; i++)
         {
             var payload = entry.Payloads[i];
-            writer.WriteInt32(payload?.Length ?? 0);
+            output.WriteInt32(payload?.Length ?? 0);
             if (payload is { Length: > 0 })
-                writer.WriteBytes(payload);
+                output.WriteBytes(payload);
         }
     }
 }

--- a/src/core/Rowles.LeanCorpus/Index/Indexer/SegmentFlusher.cs
+++ b/src/core/Rowles.LeanCorpus/Index/Indexer/SegmentFlusher.cs
@@ -460,7 +460,7 @@ internal static class SegmentFlusher
         string posPath = basePath + ".pos";
         using (var posOutput = new IndexOutput(posPath, durable: true, dropPageCache: true))
         {
-            PostingsFileHeader.WriteV2Header(posOutput);
+            using var scope = CodecFileHeader.BeginStreamingWrite(posOutput, CodecConstants.PostingsVersion);
 
             using var blockWriter = new BlockPostingsWriter(posOutput);
 

--- a/src/core/Rowles.LeanCorpus/Index/Migration/IndexCodecMigrator.cs
+++ b/src/core/Rowles.LeanCorpus/Index/Migration/IndexCodecMigrator.cs
@@ -1,4 +1,5 @@
 using Rowles.LeanCorpus.Codecs.CodecKit;
+using System.Buffers;
 using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
 using System.Diagnostics;
 using Rowles.LeanCorpus.Codecs;
@@ -770,78 +771,72 @@ public static class IndexCodecMigrator
         var sourceBase = Path.Combine(targetDirectory, sourceSegmentId);
         var targetBase = Path.Combine(targetDirectory, targetSegmentId);
 
-        List<(string Term, List<PostingRow> Postings)> terms;
-        using (var dictionary = TermDictionaryReader.Open(sourceBase + ".dic"))
-        using (var input = new IndexInput(sourceBase + ".pos"))
-        {
-            _ = PostingsEnum.ValidateFileHeader(input);
-            terms = dictionary
-                .EnumerateAllTerms()
-                .Select(term => (term.Term, ReadPostingRows(input, term.Offset)))
-                .ToList();
-        }
-
         var normsData = NormsReader.Read(sourceBase + ".nrm");
-
-        var postingsOffsets = new Dictionary<string, long>(terms.Count, StringComparer.Ordinal);
 
         var posPath = targetBase + ".pos";
         var dicPath = targetBase + ".dic";
         var temporaryPosPath = posPath + ".tmp";
         var temporaryDicPath = dicPath + ".tmp";
 
+        var postingsOffsets = new Dictionary<string, long>(StringComparer.Ordinal);
+        var termList = new List<string>();
+
         try
         {
-            // Write v2 directly — no temp body file, no envelope.
-            using (var bodyOutput = new IndexOutput(temporaryPosPath, durable: true))
+            // Open input and output together so lazy enumeration can stream.
+            using var dictionary = TermDictionaryReader.Open(sourceBase + ".dic");
+            using var input = new IndexInput(sourceBase + ".pos");
+            _ = PostingsEnum.ValidateFileHeader(input);
+
+            using var bodyOutput = new IndexOutput(temporaryPosPath, durable: true);
+            using var scope = CodecFileHeader.BeginStreamingWrite(bodyOutput, CodecConstants.PostingsVersion);
+            using var blockWriter = new BlockPostingsWriter(bodyOutput);
+
+            foreach (var (term, offset) in dictionary.EnumerateTerms())
             {
-                PostingsFileHeader.WriteV2Header(bodyOutput);
+                var postings = ReadPostingRows(input, offset);
+                termList.Add(term);
 
-                using var blockWriter = new BlockPostingsWriter(bodyOutput);
+                bool hasFreqs = postings.Any(static p => p.Frequency != 1);
+                bool hasPositions = postings.Any(static p => p.Positions.Length > 0);
+                bool hasPayloads = postings.Any(static p => p.Payloads.Any(static pl => pl.Length > 0));
 
-                foreach (var (term, postings) in terms)
+                string fieldName = QualifiedTermHelpers.GetFieldName(term).ToString();
+                normsData.Norms.TryGetValue(fieldName, out var fieldNormBytes);
+
+                long headerPos = bodyOutput.Position;
+                postingsOffsets[term] = headerPos;
+                bodyOutput.WriteInt32(0);     // docFreq placeholder
+                bodyOutput.WriteInt64(0L);    // skipOffset placeholder
+                bodyOutput.WriteBoolean(hasFreqs);
+                bodyOutput.WriteBoolean(hasPositions);
+                bodyOutput.WriteBoolean(hasPayloads);
+
+                blockWriter.StartTerm();
+                foreach (var posting in postings)
                 {
-                    bool hasFreqs = postings.Any(static posting => posting.Frequency != 1);
-                    bool hasPositions = postings.Any(static posting => posting.Positions.Length > 0);
-                    bool hasPayloads = postings.Any(static posting => posting.Payloads.Any(static payload => payload.Length > 0));
-
-                    string fieldName = QualifiedTermHelpers.GetFieldName(term).ToString();
-                    normsData.Norms.TryGetValue(fieldName, out var fieldNormBytes);
-
-                    long headerPos = bodyOutput.Position;
-                    postingsOffsets[term] = headerPos;
-                    bodyOutput.WriteInt32(0);     // docFreq placeholder
-                    bodyOutput.WriteInt64(0L);    // skipOffset placeholder
-                    bodyOutput.WriteBoolean(hasFreqs);
-                    bodyOutput.WriteBoolean(hasPositions);
-                    bodyOutput.WriteBoolean(hasPayloads);
-
-                    blockWriter.StartTerm();
-                    foreach (var posting in postings)
-                    {
-                        int docId = posting.DocId;
-                        byte norm = fieldNormBytes is not null && (uint)docId < (uint)fieldNormBytes.Length
-                            ? fieldNormBytes[docId]
-                            : (byte)0;
-                        blockWriter.AddPosting(docId, hasFreqs ? posting.Frequency : 1, norm);
-                    }
-                    var metadata = blockWriter.FinishTerm();
-
-                    if (hasPositions)
-                        WritePositionRows(bodyOutput, postings, hasPayloads);
-
-                    // Patch term header in place — v2 has no envelope, offsets are file-absolute.
-                    long endPos = bodyOutput.Position;
-                    bodyOutput.Seek(headerPos);
-                    bodyOutput.WriteInt32(metadata.DocFreq);
-                    bodyOutput.WriteInt64(metadata.SkipOffset);
-                    bodyOutput.Seek(endPos);
+                    int docId = posting.DocId;
+                    byte norm = fieldNormBytes is not null && (uint)docId < (uint)fieldNormBytes.Length
+                        ? fieldNormBytes[docId]
+                        : (byte)0;
+                    blockWriter.AddPosting(docId, hasFreqs ? posting.Frequency : 1, norm);
                 }
-            }
+                var metadata = blockWriter.FinishTerm();
 
-            // v2 has no envelope — offsets are already correct.
-            TermDictionaryWriter.Write(temporaryDicPath,
-                postingsOffsets.Keys.Order(StringComparer.Ordinal).ToList(), postingsOffsets);
+                if (hasPositions)
+                    WritePositionRows(bodyOutput, postings, hasPayloads);
+
+                // Patch term header in place; trailer has no VarInt64, offsets are file-absolute.
+                long endPos = bodyOutput.Position;
+                bodyOutput.Seek(headerPos);
+                bodyOutput.WriteInt32(metadata.DocFreq);
+                bodyOutput.WriteInt64(metadata.SkipOffset);
+                bodyOutput.Seek(endPos);
+            }
+            // scope.Dispose() writes 8-byte trailer here.
+
+            // Terms are in FST sorted byte order; TermDictionaryWriter re-encodes + re-sorts.
+            TermDictionaryWriter.Write(temporaryDicPath, termList, postingsOffsets);
             File.Move(temporaryPosPath, posPath, overwrite: true);
             File.Move(temporaryDicPath, dicPath, overwrite: true);
         }
@@ -864,7 +859,23 @@ public static class IndexCodecMigrator
                 presenceSets[field] = bitmap.ToHashSet();
         }
 
-        WriteSingleFileAtomically(sourcePath, targetPath, temporaryPath => NumericDocValuesWriter.Write(temporaryPath, values, docCount, presenceSets));
+        var temporaryPath = targetPath + ".tmp";
+        var fieldBuf = new ArrayBufferWriter<byte>(4096);
+        try
+        {
+            using var output = new IndexOutput(temporaryPath, durable: true);
+            using var scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.NumericDocValuesVersion);
+            scope.Output.WriteInt32(values.Count);
+            foreach (var (fieldName, fieldValues) in values)
+            {
+                presenceSets.TryGetValue(fieldName, out var pres);
+                fieldBuf.Clear();
+                NumericDocValuesWriter.WriteFieldBlock(fieldBuf, fieldName, fieldValues, docCount, pres);
+                scope.Output.WriteBytes(fieldBuf.WrittenSpan);
+            }
+            File.Move(temporaryPath, targetPath, overwrite: true);
+        }
+        catch { TryDeleteTemporaryFile(temporaryPath); throw; }
     }
 
     private static void RewriteSortedDocValues(string sourcePath, string targetPath)
@@ -875,29 +886,58 @@ public static class IndexCodecMigrator
             static item => item.Key,
             static item => item.Value.Select(static value => (string?)value).ToArray(),
             StringComparer.Ordinal);
-        WriteSingleFileAtomically(sourcePath, targetPath, temporaryPath => SortedDocValuesWriter.Write(temporaryPath, nullableValues, docCount));
+
+        var temporaryPath = targetPath + ".tmp";
+        var fieldBuf = new ArrayBufferWriter<byte>(4096);
+        try
+        {
+            using var output = new IndexOutput(temporaryPath, durable: true);
+            using var scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.SortedDocValuesVersion);
+            scope.Output.WriteInt32(nullableValues.Count);
+            foreach (var (fieldName, fieldValues) in nullableValues)
+            {
+                fieldBuf.Clear();
+                SortedDocValuesWriter.WriteFieldBlock(fieldBuf, fieldName, fieldValues, docCount);
+                scope.Output.WriteBytes(fieldBuf.WrittenSpan);
+            }
+            File.Move(temporaryPath, targetPath, overwrite: true);
+        }
+        catch { TryDeleteTemporaryFile(temporaryPath); throw; }
     }
 
     private static void RewriteNorms(string sourcePath, string targetPath)
     {
         var values = NormsReader.Read(sourcePath);
-        var fieldNorms = values.Norms.ToDictionary(
-            static item => item.Key,
-            static item =>
-            {
-                var norms = new float[item.Value.Length];
-                for (int i = 0; i < item.Value.Length; i++)
-                    norms[i] = item.Value[i] / 255f;
-                return norms;
-            },
-            StringComparer.Ordinal);
-
-        IReadOnlyDictionary<string, float[]>? fieldBoosts = values.Boosts.Count > 0
-            ? values.Boosts
-            : null;
+        var fieldNorms = new Dictionary<string, float[]>(values.Norms.Count, StringComparer.Ordinal);
+        foreach (var (field, bytes) in values.Norms)
+        {
+            var norms = new float[bytes.Length];
+            for (int i = 0; i < bytes.Length; i++)
+                norms[i] = bytes[i] / 255f;
+            fieldNorms[field] = norms;
+        }
 
         var docCount = fieldNorms.Count == 0 ? 0 : fieldNorms.Values.Max(static field => field.Length);
-        WriteSingleFileAtomically(sourcePath, targetPath, temporaryPath => NormsWriter.Write(temporaryPath, fieldNorms, fieldBoosts, docCount));
+        var fieldBoosts = values.Boosts.Count > 0 ? values.Boosts : null;
+
+        var temporaryPath = targetPath + ".tmp";
+        var fieldBuf = new ArrayBufferWriter<byte>(4096);
+        try
+        {
+            using var output = new IndexOutput(temporaryPath, durable: true);
+            using var scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.NormsVersion);
+            scope.Output.WriteInt32(fieldNorms.Count);
+            foreach (var (fieldName, norms) in fieldNorms)
+            {
+                float[]? boosts = null;
+                fieldBoosts?.TryGetValue(fieldName, out boosts);
+                fieldBuf.Clear();
+                NormsWriter.WriteFieldBlock(fieldBuf, fieldName, norms, boosts, docCount);
+                scope.Output.WriteBytes(fieldBuf.WrittenSpan);
+            }
+            File.Move(temporaryPath, targetPath, overwrite: true);
+        }
+        catch { TryDeleteTemporaryFile(temporaryPath); throw; }
     }
 
     private static void RewriteSortedSetDocValues(string sourcePath, string targetPath)
@@ -908,7 +948,22 @@ public static class IndexCodecMigrator
         foreach (var (field, fieldValues) in values)
             columns[field] = fieldValues;
 
-        WriteSingleFileAtomically(sourcePath, targetPath, temporaryPath => SortedSetDocValuesWriter.Write(temporaryPath, columns, docCount));
+        var temporaryPath = targetPath + ".tmp";
+        var fieldBuf = new ArrayBufferWriter<byte>(4096);
+        try
+        {
+            using var output = new IndexOutput(temporaryPath, durable: true);
+            using var scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.SortedSetDocValuesVersion);
+            scope.Output.WriteInt32(columns.Count);
+            foreach (var (fieldName, fieldValues) in columns)
+            {
+                fieldBuf.Clear();
+                SortedSetDocValuesWriter.WriteFieldBlock(fieldBuf, fieldName, fieldValues, docCount);
+                scope.Output.WriteBytes(fieldBuf.WrittenSpan);
+            }
+            File.Move(temporaryPath, targetPath, overwrite: true);
+        }
+        catch { TryDeleteTemporaryFile(temporaryPath); throw; }
     }
 
     private static void RewriteSortedNumericDocValues(string sourcePath, string targetPath)
@@ -919,7 +974,22 @@ public static class IndexCodecMigrator
         foreach (var (field, fieldValues) in values)
             columns[field] = fieldValues;
 
-        WriteSingleFileAtomically(sourcePath, targetPath, temporaryPath => SortedNumericDocValuesWriter.Write(temporaryPath, columns, docCount));
+        var temporaryPath = targetPath + ".tmp";
+        var fieldBuf = new ArrayBufferWriter<byte>(4096);
+        try
+        {
+            using var output = new IndexOutput(temporaryPath, durable: true);
+            using var scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.SortedNumericDocValuesVersion);
+            scope.Output.WriteInt32(columns.Count);
+            foreach (var (fieldName, fieldValues) in columns)
+            {
+                fieldBuf.Clear();
+                SortedNumericDocValuesWriter.WriteFieldBlock(fieldBuf, fieldName, fieldValues, docCount);
+                scope.Output.WriteBytes(fieldBuf.WrittenSpan);
+            }
+            File.Move(temporaryPath, targetPath, overwrite: true);
+        }
+        catch { TryDeleteTemporaryFile(temporaryPath); throw; }
     }
 
     private static void RewriteBinaryDocValues(string sourcePath, string targetPath)
@@ -930,29 +1000,45 @@ public static class IndexCodecMigrator
         foreach (var (field, fieldValues) in values)
             columns[field] = fieldValues;
 
-        WriteSingleFileAtomically(sourcePath, targetPath, temporaryPath => BinaryDocValuesWriter.Write(temporaryPath, columns, docCount));
+        var temporaryPath = targetPath + ".tmp";
+        var fieldBuf = new ArrayBufferWriter<byte>(4096);
+        try
+        {
+            using var output = new IndexOutput(temporaryPath, durable: true);
+            using var scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.BinaryDocValuesVersion);
+            scope.Output.WriteInt32(columns.Count);
+            foreach (var (fieldName, fieldValues) in columns)
+            {
+                fieldBuf.Clear();
+                BinaryDocValuesWriter.WriteFieldBlock(fieldBuf, fieldName, fieldValues, docCount);
+                scope.Output.WriteBytes(fieldBuf.WrittenSpan);
+            }
+            File.Move(temporaryPath, targetPath, overwrite: true);
+        }
+        catch { TryDeleteTemporaryFile(temporaryPath); throw; }
     }
 
     private static void RewriteFieldLengths(string sourcePath, string targetPath)
     {
         var values = FieldLengthReader.TryRead(sourcePath) ?? new Dictionary<string, int[]>(StringComparer.Ordinal);
         var docCount = values.Count == 0 ? 0 : values.Values.Max(static field => field.Length);
-        WriteSingleFileAtomically(sourcePath, targetPath, temporaryPath => FieldLengthWriter.Write(temporaryPath, values, docCount));
-    }
 
-    private static void WriteSingleFileAtomically(string sourcePath, string targetPath, Action<string> writeTemporary)
-    {
         var temporaryPath = targetPath + ".tmp";
+        var fieldBuf = new ArrayBufferWriter<byte>(4096);
         try
         {
-            writeTemporary(temporaryPath);
+            using var output = new IndexOutput(temporaryPath, durable: true);
+            using var scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.FieldLengthVersion);
+            scope.Output.WriteInt32(values.Count);
+            foreach (var (fieldName, lengths) in values)
+            {
+                fieldBuf.Clear();
+                FieldLengthWriter.WriteFieldBlock(fieldBuf, fieldName, lengths);
+                scope.Output.WriteBytes(fieldBuf.WrittenSpan);
+            }
             File.Move(temporaryPath, targetPath, overwrite: true);
         }
-        catch
-        {
-            TryDeleteTemporaryFile(temporaryPath);
-            throw;
-        }
+        catch { TryDeleteTemporaryFile(temporaryPath); throw; }
     }
 
     private static List<PostingRow> ReadPostingRows(IndexInput input, long offset)

--- a/src/core/Rowles.LeanCorpus/Store/IndexOutput.cs
+++ b/src/core/Rowles.LeanCorpus/Store/IndexOutput.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Rowles.LeanCorpus.Store;
 
@@ -116,6 +117,64 @@ public sealed class IndexOutput : IDisposable
             FlushBuffer();
 
         _buffer[_bufferPosition++] = value;
+    }
+
+    /// <summary>
+    /// Writes a non-negative integer using 7-bit encoding,
+    /// compatible with <see cref="System.IO.BinaryWriter.Write7BitEncodedInt"/>.
+    /// Small values (0–127) consume a single byte.
+    /// </summary>
+    public void Write7BitEncodedInt(int value)
+    {
+        uint v = (uint)value;
+        Span<byte> buf = stackalloc byte[5];
+        int pos = 0;
+        while (v >= 0x80)
+        {
+            buf[pos++] = (byte)(v | 0x80);
+            v >>= 7;
+        }
+        buf[pos++] = (byte)v;
+        WriteBytes(buf[..pos]);
+    }
+
+    /// <summary>
+    /// Writes a length-prefixed UTF-8 string, compatible with
+    /// <see cref="System.IO.BinaryWriter.Write(string)"/>.
+    /// </summary>
+    public void WriteString(string value)
+    {
+        int byteCount = Encoding.UTF8.GetByteCount(value);
+        Write7BitEncodedInt(byteCount);
+        if (byteCount <= 256)
+        {
+            Span<byte> buf = stackalloc byte[256];
+            Encoding.UTF8.GetBytes(value, buf);
+            WriteBytes(buf[..byteCount]);
+        }
+        else
+        {
+            WriteBytes(Encoding.UTF8.GetBytes(value));
+        }
+    }
+
+    /// <summary>
+    /// Writes a char span as raw UTF-8 bytes (no length prefix).
+    /// Compatible with <see cref="System.IO.BinaryWriter.Write(char[])"/>.
+    /// </summary>
+    public void WriteChars(ReadOnlySpan<char> chars)
+    {
+        int byteCount = Encoding.UTF8.GetByteCount(chars);
+        if (byteCount <= 256)
+        {
+            Span<byte> buf = stackalloc byte[256];
+            Encoding.UTF8.GetBytes(chars, buf);
+            WriteBytes(buf[..byteCount]);
+        }
+        else
+        {
+            WriteBytes(Encoding.UTF8.GetBytes(chars.ToArray(), 0, chars.Length));
+        }
     }
 
     /// <summary>

--- a/src/devops/Rowles.LeanCorpus.Tests.Chaos/Index/FieldPayloadChaosTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Chaos/Index/FieldPayloadChaosTests.cs
@@ -41,9 +41,9 @@ public sealed class FieldPayloadChaosTests : IClassFixture<ChaosDirectoryFixture
                 }
             ]);
 
+        // v3 trailer has 8-byte trailer at end; truncate past it into the body.
         using (var stream = new FileStream(basePath + ".tvd", FileMode.Open, FileAccess.Write, FileShare.None))
-            stream.SetLength(stream.Length - 1);
-
+            stream.SetLength(stream.Length - 10);
         using var reader = TermVectorsReader.Open(basePath + ".tvd", basePath + ".tvx");
         Assert.ThrowsAny<Exception>(() => reader.GetTermVector(0));
     }

--- a/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/CodecKit/CodecFileHeaderTrailerTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/CodecKit/CodecFileHeaderTrailerTests.cs
@@ -1,0 +1,241 @@
+using Rowles.LeanCorpus.Codecs;
+using Rowles.LeanCorpus.Codecs.CodecKit;
+using Rowles.LeanCorpus.Codecs.CodecKit.Codecs;
+using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
+
+namespace Rowles.LeanCorpus.Tests.Unit.Codecs.CodecKit;
+
+[Trait("Category", "CodecKit")]
+public sealed class CodecFileHeaderTrailerTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public CodecFileHeaderTrailerTests()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "LeanCorpus_TrailerTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            try { Directory.Delete(_tempDirectory, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+
+    private string TempFile(string name) => Path.Combine(_tempDirectory, name);
+
+    // ═══════════════════════════════════════════════════
+    //  Round-trip tests
+    // ═══════════════════════════════════════════════════
+
+    [Theory(DisplayName = "Trailer round-trip via BeginStreamingWrite + ReadBody")]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(1024)]
+    [InlineData(1_048_576)]
+    public void Trailer_RoundTrip_WritesAndReadsCorrectly(int bodySize)
+    {
+        byte version = 42;
+        var original = new byte[bodySize];
+        for (int i = 0; i < bodySize; i++) original[i] = (byte)(i & 0xFF);
+
+        var path = TempFile($"roundtrip_{bodySize}.dat");
+
+        // Write via trailer
+        using (var output = new IndexOutput(path, durable: false))
+        using (var scope = CodecFileHeader.BeginStreamingWrite(output, version))
+        {
+            if (bodySize > 0)
+                scope.Output.WriteBytes(original);
+        }
+
+        // Read via ReadBody
+        using var input = new IndexInput(path);
+        var result = CodecFileHeader.ReadBody(input);
+
+        Assert.Equal(version, result.Version);
+        Assert.Equal(original, result.Body);
+    }
+
+    // ═══════════════════════════════════════════════════
+    //  Envelope fallback tests
+    // ═══════════════════════════════════════════════════
+
+    [Fact(DisplayName = "ReadBody reads old envelope format correctly")]
+    public void Trailer_EnvelopeFallback_ReadsOldFormatCorrectly()
+    {
+        var original = new byte[] { 1, 2, 3, 4, 5 };
+        var path = TempFile("envelope_fallback.dat");
+
+        // Write via old envelope path
+        using (var output = new IndexOutput(path, durable: false))
+            CodecFileHeader.Write(output, CodecFormats.BinaryDocValues, original);
+
+        // Read via ReadBody — should detect envelope format
+        using var input = new IndexInput(path);
+        var result = CodecFileHeader.ReadBody(input);
+
+        Assert.Equal(CodecConstants.BinaryDocValuesVersion, result.Version);
+        Assert.Equal(original, result.Body);
+    }
+
+    [Fact(DisplayName = "ReadBody correctly detects trailer then envelope in same reader")]
+    public void Trailer_DetectsTrailerThenEnvelope_InSameReader()
+    {
+        var original = new byte[] { 9, 8, 7 };
+
+        // Write a trailer file
+        var trailerPath = TempFile("detect_trailer.dat");
+        using (var output = new IndexOutput(trailerPath, durable: false))
+        using (var scope = CodecFileHeader.BeginStreamingWrite(output, 77))
+        {
+            scope.Output.WriteBytes(original);
+        }
+
+        // Write an envelope file
+        var envelopePath = TempFile("detect_envelope.dat");
+        using (var output = new IndexOutput(envelopePath, durable: false))
+            CodecFileHeader.Write(output, CodecFormats.BinaryDocValues, original);
+
+        // Read both through the same code path
+        using (var input = new IndexInput(trailerPath))
+        {
+            var trailerResult = CodecFileHeader.ReadBody(input);
+            Assert.Equal(77, trailerResult.Version);
+            Assert.Equal(original, trailerResult.Body);
+        }
+
+        using (var input = new IndexInput(envelopePath))
+        {
+            var envelopeResult = CodecFileHeader.ReadBody(input);
+            Assert.Equal(CodecConstants.BinaryDocValuesVersion, envelopeResult.Version);
+            Assert.Equal(original, envelopeResult.Body);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════
+    //  Error / corruption tests
+    // ═══════════════════════════════════════════════════
+
+    [Fact(DisplayName = "ReadBody throws on truncated file")]
+    public void Trailer_RejectsTruncatedFile()
+    {
+        var path = TempFile("truncated.dat");
+
+        // Write a valid trailer file, then truncate to just the version byte.
+        var original = new byte[] { 10, 20, 30, 40 };
+        using (var output = new IndexOutput(path, durable: false))
+        using (var scope = CodecFileHeader.BeginStreamingWrite(output, 1))
+        {
+            scope.Output.WriteBytes(original);
+        }
+
+        // Truncate to 1 byte: version only, no body, no trailer.
+        using (var fs = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.None))
+            fs.SetLength(1);
+
+        // ReadBody should fail: trailer check fails (file too short),
+        // envelope fallback fails because ReadVarInt64 can't read past EOF.
+        using var input = new IndexInput(path);
+        Assert.ThrowsAny<Exception>(() => CodecFileHeader.ReadBody(input));
+    }
+
+    [Fact(DisplayName = "ReadBody rejects corrupt trailer length")]
+    public void Trailer_RejectsCorruptTrailerLength()
+    {
+        var original = new byte[] { 1, 2, 3 };
+        var path = TempFile("corrupt_trailer.dat");
+
+        using (var output = new IndexOutput(path, durable: false))
+        using (var scope = CodecFileHeader.BeginStreamingWrite(output, 99))
+        {
+            scope.Output.WriteBytes(original);
+        }
+
+        // Corrupt the last 8 bytes to an inconsistent value
+        using (var fs = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.None))
+        {
+            fs.Seek(-8, SeekOrigin.End);
+            fs.Write(BitConverter.GetBytes(999_999L));
+        }
+
+        // Trailer check fails (inconsistent), falls back to envelope
+        // Envelope parsing fails because bodyLen is garbage
+        using var input = new IndexInput(path);
+        Assert.Throws<InvalidDataException>(() => CodecFileHeader.ReadBody(input));
+    }
+
+    [Fact(DisplayName = "ReadBody handles 9-byte empty-body trailer file")]
+    public void Trailer_ReadBody_EmptyFile()
+    {
+        var path = TempFile("empty_body.dat");
+
+        // 9 bytes: version(1) + body(0) + trailer(8)
+        using (var output = new IndexOutput(path, durable: false))
+        using (var scope = CodecFileHeader.BeginStreamingWrite(output, 7))
+        {
+            // no body written
+        }
+
+        using var input = new IndexInput(path);
+        var result = CodecFileHeader.ReadBody(input);
+
+        Assert.Equal(7, result.Version);
+        Assert.Empty(result.Body);
+        Assert.Equal(9L, input.Length);
+    }
+
+    // ═══════════════════════════════════════════════════
+    //  ReadVersionAndSkipHeader positioning tests
+    // ═══════════════════════════════════════════════════
+
+    [Fact(DisplayName = "ReadVersionAndSkipHeader positions at body start for trailer format")]
+    public void ReadVersionAndSkipHeader_PositionsAtBodyStart_Trailer()
+    {
+        var body = new byte[] { 0xAA, 0xBB, 0xCC, 0xDD };
+        var path = TempFile("skip_trailer.dat");
+
+        using (var output = new IndexOutput(path, durable: false))
+        using (var scope = CodecFileHeader.BeginStreamingWrite(output, 55))
+        {
+            scope.Output.WriteBytes(body);
+        }
+
+        using var input = new IndexInput(path);
+        byte version = CodecFileHeader.ReadVersionAndSkipHeader(input);
+
+        Assert.Equal(55, version);
+        Assert.Equal(1L, input.Position); // body starts immediately after version byte
+        Assert.Equal(body[0], input.ReadByte());
+    }
+
+    [Fact(DisplayName = "ReadVersionAndSkipHeader positions at body start for envelope format")]
+    public void ReadVersionAndSkipHeader_PositionsAtBodyStart_Envelope()
+    {
+        var body = new byte[] { 0x11, 0x22, 0x33 };
+        var path = TempFile("skip_envelope.dat");
+
+        using (var output = new IndexOutput(path, durable: false))
+            CodecFileHeader.Write(output, CodecFormats.BinaryDocValues, body);
+
+        using var input = new IndexInput(path);
+        byte version = CodecFileHeader.ReadVersionAndSkipHeader(input);
+
+        Assert.Equal(CodecConstants.BinaryDocValuesVersion, version);
+        // Body should start after version(1) + VarInt64 bodyLen
+        Assert.True(input.Position > 1L);
+        Assert.Equal(body[0], input.ReadByte());
+    }
+
+    // BinaryReader ReadVersionAndSkipHeader omitted for Phase A —
+    // the BinaryReader overload is envelope-only until Phase C.}
+}

--- a/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/CodecsTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/CodecsTests.cs
@@ -106,7 +106,7 @@ public sealed class CodecsTests : IClassFixture<TestDirectoryFixture>
             WriteVarInt(bodyWriter, 3);
             bodyWriter.Flush();
             using var output = new IndexOutput(filePath);
-            PostingsFileHeader.WriteV2Header(output);
+            using var _scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.PostingsVersion);
             output.WriteBytes(bodyMs.ToArray());
         }
         var readIds = PostingsReader.ReadDocIds(filePath, "testterm");
@@ -138,7 +138,7 @@ public sealed class CodecsTests : IClassFixture<TestDirectoryFixture>
             innerWriter.Flush();
             byte[] body = ms.ToArray();
             using var output = new IndexOutput(filePath);
-            PostingsFileHeader.WriteV2Header(output);
+            using var _scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.PostingsVersion);
             output.WriteBytes(body);
         }
 

--- a/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/PayloadRoundTripTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/PayloadRoundTripTests.cs
@@ -81,7 +81,7 @@ public sealed class PayloadRoundTripTests : IDisposable
     private static void WritePosFile(string posPath, int[] docIds, int[] freqs, out long termOffset)
     {
         using var output = new IndexOutput(posPath);
-        PostingsFileHeader.WriteV2Header(output);
+        using var _scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.PostingsVersion);
 
         using var bw = new BlockPostingsWriter(output);
         long headerPos = output.Position;

--- a/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/PostingsEnumGapsTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/PostingsEnumGapsTests.cs
@@ -28,8 +28,9 @@ public sealed class PostingsEnumGapsTests : IDisposable
     {
         var path = Path.Combine(_dir, "test_valid.pos");
         using (var output = new IndexOutput(path))
-            PostingsFileHeader.WriteV2Header(output);
-
+        {
+            using var _scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.PostingsVersion);
+        }
         using var input = new IndexInput(path);
         byte version = PostingsEnum.ValidateFileHeader(input);
         Assert.Equal(CodecConstants.PostingsVersion, version);
@@ -129,7 +130,7 @@ public sealed class PostingsEnumGapsTests : IDisposable
         long offset;
         using (var output = new IndexOutput(path))
         {
-            PostingsFileHeader.WriteV2Header(output);
+            using var _scope = CodecFileHeader.BeginStreamingWrite(output, CodecConstants.PostingsVersion);
 
             long headerPos = output.Position;
             output.WriteInt32(0);             // docFreq placeholder

--- a/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/StoredFieldsStreamingTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/StoredFieldsStreamingTests.cs
@@ -11,10 +11,10 @@ public sealed class StoredFieldsStreamingTests : IClassFixture<TestDirectoryFixt
 
     public StoredFieldsStreamingTests(TestDirectoryFixture fixture) => _fixture = fixture;
 
-    [Fact(DisplayName = "Stored Fields v2: writer emits version 2")]
-    public void Writer_EmitsVersion2()
+    [Fact(DisplayName = "Stored Fields v3: writer emits version 3")]
+    public void Writer_EmitsVersion3()
     {
-        var path = Path.Combine(_fixture.Path, $"sf-v2-{Guid.NewGuid():N}");
+        var path = Path.Combine(_fixture.Path, $"sf-v3-{Guid.NewGuid():N}");
         var docs = new[]
         {
             new Dictionary<string, List<StoredFieldValue>>(StringComparer.Ordinal)
@@ -25,8 +25,8 @@ public sealed class StoredFieldsStreamingTests : IClassFixture<TestDirectoryFixt
 
         StoredFieldsWriter.Write(path + ".fdt", path + ".fdx", docs.Length, docId => docs[docId]);
 
-        Assert.Equal(StoredFieldsFileHeader.V2, File.ReadAllBytes(path + ".fdt")[0]);
-        Assert.Equal(StoredFieldsFileHeader.V2, File.ReadAllBytes(path + ".fdx")[0]);
+        Assert.Equal(StoredFieldsFileHeader.V3, File.ReadAllBytes(path + ".fdt")[0]);
+        Assert.Equal(StoredFieldsFileHeader.V3, File.ReadAllBytes(path + ".fdx")[0]);
     }
 
     [Fact(DisplayName = "Stored Fields v2: round-trip many documents")]
@@ -149,8 +149,8 @@ public sealed class StoredFieldsStreamingTests : IClassFixture<TestDirectoryFixt
     public void Reader_RejectsFutureVersion()
     {
         var path = Path.Combine(_fixture.Path, $"sf-future-{Guid.NewGuid():N}");
-        File.WriteAllBytes(path + ".fdt", [(byte)(StoredFieldsFileHeader.V2 + 1), 16, 0, 0, 0, 0]);
-        File.WriteAllBytes(path + ".fdx", [(byte)(StoredFieldsFileHeader.V2 + 1), 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        File.WriteAllBytes(path + ".fdt", [(byte)(StoredFieldsFileHeader.V3 + 1), 16, 0, 0, 0, 0]);
+        File.WriteAllBytes(path + ".fdx", [(byte)(StoredFieldsFileHeader.V3 + 1), 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
         var ex = Assert.Throws<InvalidDataException>(() => StoredFieldsReader.Open(path + ".fdt", path + ".fdx"));
         Assert.Contains("format version", ex.Message, StringComparison.OrdinalIgnoreCase);

--- a/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/StreamingPostingsMergerTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Unit/Codecs/StreamingPostingsMergerTests.cs
@@ -1,4 +1,5 @@
 using Rowles.LeanCorpus.Codecs.CodecKit;
+using Rowles.LeanCorpus.Codecs;
 using Rowles.LeanCorpus.Tests.Shared.Fixtures;
 using Rowles.LeanCorpus.Codecs.CodecKit.Formats;
 using Rowles.LeanCorpus.Codecs.Postings;
@@ -122,7 +123,7 @@ public sealed class StreamingPostingsMergerTests : IDisposable
         // Write v2 postings directly — no temp file, no envelope patching.
         using (var posOutput = new IndexOutput(posPath))
         {
-            PostingsFileHeader.WriteV2Header(posOutput);
+            using var _scope = CodecFileHeader.BeginStreamingWrite(posOutput, CodecConstants.PostingsVersion);
 
             using var blockWriter = new BlockPostingsWriter(posOutput);
             foreach (var term in terms)


### PR DESCRIPTION
Add CodecKit trailer format with BeginStreamingWrite, ReadVersionAndSkipHeader, ReadBody; bump 12 codec versions; convert all migrator rewrite methods, stored fields, postings, and term vectors to streaming v3 writes